### PR TITLE
FIX - resolve CodeQL security alerts

### DIFF
--- a/frontend/src/utils/appStorePreviews.test.ts
+++ b/frontend/src/utils/appStorePreviews.test.ts
@@ -10,6 +10,10 @@ import {
   PREVIEWABLE_BUILTIN_APP_IDS,
 } from '@/utils/appStorePreviews'
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 describe('App Store preview catalog', () => {
   it('contains a real captured screenshot for every built-in store app', () => {
     const storeAppIds = PHONE_APPS.filter(
@@ -56,10 +60,11 @@ describe('App Store preview catalog', () => {
     ]
 
     for (const appId of PREVIEWABLE_BUILTIN_APP_IDS) {
+      const escapedAppId = escapeRegExp(appId)
       for (const source of localeSources) {
         expect(source).toMatch(
           new RegExp(
-            `(?:["']${appId}["']\\]?|${appId.replace(/-/g, '\\-')})\\s*[:=]\\s*\\{\\s*first\\s*[:=]`,
+            `(?:["']${escapedAppId}["']\\]?|${escapedAppId})\\s*[:=]\\s*\\{\\s*first\\s*[:=]`,
           ),
         )
       }

--- a/frontend/src/utils/lbPhoneAppBridge.test.ts
+++ b/frontend/src/utils/lbPhoneAppBridge.test.ts
@@ -112,8 +112,16 @@ describe('LB Phone app bridge', () => {
     expect(document).toContain('https://cfx-nui-snake_app/ui/dist/')
     expect(document).not.toContain('</script><script>window.injected=true')
 
-    const runtime = /<script>([\s\S]*?)<\/script>/.exec(document)?.[1]
-    expect(runtime).toBeTruthy()
-    expect(() => new Function(runtime ?? '')).not.toThrow()
+    const openingTag = '<script>'
+    const runtimeStart = document.indexOf(openingTag)
+    const runtimeEnd = document.indexOf(
+      '</script>',
+      runtimeStart + openingTag.length,
+    )
+    expect(runtimeStart).toBeGreaterThanOrEqual(0)
+    expect(runtimeEnd).toBeGreaterThan(runtimeStart)
+
+    const runtime = document.slice(runtimeStart + openingTag.length, runtimeEnd)
+    expect(() => new Function(runtime)).not.toThrow()
   })
 })

--- a/frontend/src/utils/notes.test.ts
+++ b/frontend/src/utils/notes.test.ts
@@ -47,4 +47,12 @@ describe('notes rich text', () => {
       'Briefing\nMeet outside.\n• Radio\n• Vest',
     )
   })
+
+  it('keeps encoded markup as literal preview text', () => {
+    const body = serializeRichNoteBody(
+      '<p>&lt;script&gt;literal&lt;/script&gt;</p>',
+    )
+
+    expect(noteBodyToPlainText(body)).toBe('<script>literal</script>')
+  })
 })

--- a/frontend/testserver/index.cjs
+++ b/frontend/testserver/index.cjs
@@ -4657,7 +4657,7 @@ app.post('/api/:endpoint', async (request, response, next) => {
   if (endpoint === 'memos:devCapture') {
     loggedBody.audioDataUrl = `<${String(request.body.audioDataUrl ?? '').length} characters>`
   }
-  console.log(`[NUI] ${endpoint}`, loggedBody)
+  console.log('[NUI]', endpoint, loggedBody)
   if (endpoint === 'music:bootstrap') {
     response.json({ success: true, data: musicBootstrap() })
     return

--- a/frontend/testserver/smoke.cjs
+++ b/frontend/testserver/smoke.cjs
@@ -1177,6 +1177,18 @@ async function main() {
       'factory reset did not restore a browser-testable setup state',
     )
 
+    const loggedRequests = []
+    const originalConsoleLog = console.log
+    try {
+      console.log = (...values) => loggedRequests.push(values)
+      await post(baseUrl, '%25s', { marker: 'format-string' })
+    } finally {
+      console.log = originalConsoleLog
+    }
+    assert.deepEqual(loggedRequests, [
+      ['[NUI]', '%s', { marker: 'format-string' }],
+    ])
+
     const unknown = await post(baseUrl, 'development:missing-mock', {})
     assert.deepEqual(unknown, {
       error: 'mock_endpoint_missing',


### PR DESCRIPTION
## Summary

- replace the test-only script extraction regex that CodeQL treated as a tag filter
- fully escape dynamic app IDs before constructing the locale-contract regex
- keep the browser mock endpoint outside Node's user-controlled format-string position and cover it with a smoke test
- document that encoded tag-like note content intentionally remains literal plain text

Code-scanning alert 1 was separately dismissed as a false positive after tracing every consumer: the value is only used through Vue text bindings or string operations, while the TipTap HTML path is independently sanitized with DOMPurify.

## Verification

- `pnpm test` (213 files, 1208 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`