### PR TITLE
FIX - use repository-native NUI build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ pnpm build
 
 ### The resource starts but the phone UI is missing
 
-- On startup, the server console prints `SKY PHONE UI BUILD IS MISSING OR INCOMPLETE` and lists the missing or invalid packaged files.
+- On startup, the server console prints `SKY PHONE UI BUILD IS MISSING OR INCOMPLETE`, lists the missing or invalid packaged files, and shows repository-native build commands.
 - Install the latest published release package rather than GitHub's automatically generated source archive.
 - Confirm `sky_phone/source/html/index.html`, `assets`, `img`, and `sounds` exist.
 - Developers working from source must run the frontend production build before starting the resource.

--- a/sky_phone/source/server/nui_build_check.lua
+++ b/sky_phone/source/server/nui_build_check.lua
@@ -112,7 +112,11 @@ local function print_missing_nui_notice(missing_paths)
     lines[#lines + 1] = ""
     lines[#lines + 1] = "^3 Install the latest published release package, not GitHub's automatic source archive.^0"
     lines[#lines + 1] = "^5 Release: https://github.com/sky-systems/sky_phone/releases/latest^0"
-    lines[#lines + 1] = "^3 Developers working from source must run build_frontend.bat before starting sky_phone.^0"
+    lines[#lines + 1] = "^3 Developers working from source:^0"
+    lines[#lines + 1] = "^5 cd frontend^0"
+    lines[#lines + 1] = "^5 pnpm install --frozen-lockfile^0"
+    lines[#lines + 1] = "^5 pnpm build^0"
+    lines[#lines + 1] = "^5 Build guide: https://github.com/sky-systems/sky_phone#frontend-development^0"
     lines[#lines + 1] = ("^1%s^0"):format(border)
 
     print(table.concat(lines, "\n"))

--- a/tests/nui_build_check.lua
+++ b/tests/nui_build_check.lua
@@ -39,7 +39,11 @@ assert(missing_build_output:find("source/html/assets/*", 1, true))
 assert(missing_build_output:find("source/html/img/custom-app.svg", 1, true))
 assert(missing_build_output:find("source/html/sounds/button.mp3", 1, true))
 assert(missing_build_output:find("not GitHub's automatic source archive", 1, true))
-assert(missing_build_output:find("build_frontend.bat", 1, true))
+assert(missing_build_output:find("cd frontend", 1, true))
+assert(missing_build_output:find("pnpm install --frozen-lockfile", 1, true))
+assert(missing_build_output:find("pnpm build", 1, true))
+assert(missing_build_output:find("https://github.com/sky-systems/sky_phone#frontend-development", 1, true))
+assert(not missing_build_output:find("build_frontend.bat", 1, true))
 
 local missing_asset_files = {}
 for path, content in pairs(valid_files) do


### PR DESCRIPTION
## Summary

Fixes the missing-NUI startup diagnostic so every source-build instruction points to content shipped in the `sky_phone` GitHub repository.

## Root cause and approach

The warning referenced `build_frontend.bat`, but that helper exists only in the parent local workspace and is not part of the `sky_phone` Git tree or GitHub source archive. The warning now prints the repository-native `frontend` pnpm workflow and links the pushed README section.

## Changes

- replace the unavailable BAT hint with `cd frontend`, `pnpm install --frozen-lockfile`, and `pnpm build`
- link the repository's `#frontend-development` guide
- reject future `build_frontend.bat` references in the startup-warning regression
- update troubleshooting copy to describe repository-native commands

## Compatibility and migrations

- No configuration, API, event, database, or frontend bundle change.
- No dependency on another `sky_*` resource.
- The published release link remains unchanged and was verified against release `0.2.5`.

## Validation

- [x] `lua54 tests/nui_build_check.lua`
- [x] Current packaged NUI passed the startup validator
- [x] Repository policy validation
- [x] `git diff --check`
- [x] `build_copy.bat` completed for ESX and Qbox
- [x] Changed runtime file matched both deployment targets by SHA-256
- [ ] Restarted live FiveM resource test remains pending

The complete 26-file Lua run was also attempted. 23 files passed; three unrelated failures already present on current `dev` remain in `client_notifications.lua`, `client_nui_server_bridge.lua`, and `public_api_server.lua`. This PR changes none of those files or contracts.

## Runtime evidence

The real local packaged NUI validates successfully, and missing-package scenarios are covered by the focused Lua regression. A restarted FXServer console check is still pending.

## Security and architecture

- [x] No state-changing or client-controlled behavior was added.
- [x] No cross-resource Sky dependency or integration was introduced.
- [x] No secret or private URL is included.

## Reviewer notes

Review focus is limited to the console instructions and their contract test.
