### PR TITLE
FIX - correct German SkyRide mode labels

### DIFF
--- a/sky_phone/config/locales/de.lua
+++ b/sky_phone/config/locales/de.lua
@@ -1228,7 +1228,7 @@ Locales["de"] = {
             },
             skyride = {
                 name = "SkyRide", loading = "Laden SkyRide", unavailable = "SkyRide nicht verfügbar", tryAgain = "Erneut versuchen",
-                mode = { rider = "Reiten", driver = "Antrieb" },
+                mode = { rider = "Passagier", driver = "Fahrer" },
                 riderEyebrow = "Fahr irgendwohin.", whereTo = "Wohin?", pickup = "Abholung", destination = "Ziel",
                 currentLocation = "Aktueller Standort", notSelected = "Nicht ausgewählt", location = "Wähle einen Ort",
                 chooseLocation = { pickup = "Abholvorgang einstellen", destination = "Ziel auswählen" },


### PR DESCRIPTION
## Summary

Corrects the German SkyRide mode selector so the displayed labels describe the actual rider and driver roles.

## Root cause and approach

The German locale used literal action/drive translations (`Reiten` and `Antrieb`) for role labels. Replace only those two locale values with the role-appropriate terms `Passagier` and `Fahrer`.

## Changes

- Rename the German SkyRide rider label to `Passagier`.
- Rename the German SkyRide driver label to `Fahrer`.

## Compatibility and migrations

None.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [ ] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes. Not applicable: no frontend source changed.
- [ ] I ran a production frontend build for frontend changes. Not applicable: no frontend source changed.
- [ ] I tested affected Lua/native behavior with experimental OAL enabled, or marked the live runtime test as pending below.
- [ ] I verified every changed NUI callback responds on every reachable path. Not applicable: no NUI callback changed.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
node .github/scripts/validate-repository.mjs
Repository policy validation passed (2 rulesets checked).

frontend/node_modules/.bin/vitest.cmd run src/stores/phone-locale-contract.test.ts
1 test file passed; 14 tests passed.

git diff --check origin/dev...HEAD
Passed with no output.
```

## Runtime evidence

Static locale-contract validation passed. Live FiveM visual verification is pending.

## Security and architecture

- [x] Consequential actions remain server-authoritative and validate identity, permissions, ownership, limits, and payloads.
- [x] This change introduces no dependency, event, export, global, config, persistence, or fallback connection to another `sky_*` resource.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

Locale-only change; no configuration, SQL, public API, event, export, or deployment migration is required.
