### PR TITLE
FIX - load all phone locale files

### DIFF
--- a/sky_phone/fxmanifest.lua
+++ b/sky_phone/fxmanifest.lua
@@ -30,9 +30,7 @@ shared_scripts {
 
 client_scripts {
     'config/config.lua',
-    'config/locales/en.lua',
-    'config/locales/de.lua',
-    'config/locales/es.lua',
+    'config/locales/*.lua',
     'source/bridge/client/callbacks.lua',
     'source/client/phone_configurator.lua',
     'source/bridge/client/framework.lua',


### PR DESCRIPTION
## Summary

Loads all phone locale files through the resource manifest so newly added locales are available without another manifest change.

## Root cause and approach

The manifest listed English, German, and Spanish individually. Any additional locale file was therefore ignored by the client unless it was manually added to the manifest.

## Changes

- Replace the three explicit locale entries with `config/locales/*.lua`
- Keep locale loading automatically aligned with files in the locale directory

## Compatibility and migrations

None.

## Validation

- [x] Reviewed the focused one-file diff
- [ ] Live FiveM resource restart pending

## Reviewer notes

This PR contains one commit and changes only `sky_phone/fxmanifest.lua`.
