### PR TITLE
FIX - allow configurable radio channel jobs

### DIFF
--- a/frontend/src/components/AdminConfigValueEditor.vue
+++ b/frontend/src/components/AdminConfigValueEditor.vue
@@ -380,10 +380,10 @@ function toggleOptionalString(event: Event): void {
 function addListRow(): void {
   const rows = Array.isArray(props.modelValue) ? [...props.modelValue] : []
   const index = rows.length
-  const value = rows.length
-    ? blankLike(rows[0])
-    : listTemplate.value
-      ? blankFromConfiguratorStructure(listTemplate.value)
+  const value = listTemplate.value
+    ? blankFromConfiguratorStructure(listTemplate.value)
+    : rows.length
+      ? blankLike(rows[0])
       : blankValue(newArrayKind.value)
   rows.push(value)
   emit('update:modelValue', rows)

--- a/frontend/src/components/AdminPanel.contract.test.ts
+++ b/frontend/src/components/AdminPanel.contract.test.ts
@@ -440,6 +440,9 @@ describe('standalone admin panel contracts', () => {
     expect(source).toContain("selectConfiguratorScope('media')")
     expect(source).not.toContain('class="admin-panel-config-meta"')
     expect(configuratorValueEditor).toContain('function addListRow()')
+    expect(configuratorValueEditor).toMatch(
+      /const value = listTemplate\.value\s+\? blankFromConfiguratorStructure\(listTemplate\.value\)\s+: rows\.length\s+\? blankLike\(rows\[0\]\)/,
+    )
     expect(configuratorValueEditor).toContain('function addTableField()')
     expect(configuratorValueEditor).toContain(
       'const canExtendTable = computed(',

--- a/frontend/src/utils/adminConfiguratorDefaults.test.ts
+++ b/frontend/src/utils/adminConfiguratorDefaults.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AdminConfiguratorStructure } from '@/types/admin'
-import { createMutableTableEntry } from '@/utils/adminConfiguratorDefaults'
+import {
+  blankFromConfiguratorStructure,
+  createMutableTableEntry,
+} from '@/utils/adminConfiguratorDefaults'
 
 describe('admin configurator defaults', () => {
   it('creates a usable company draft from its key and the server defaults', () => {
@@ -110,5 +113,34 @@ describe('admin configurator defaults', () => {
     expect(createMutableTableEntry(structure, 'FeatureFlags', 'example')).toBe(
       false,
     )
+  })
+
+  it('preserves required nested list fields in schema-derived rows', () => {
+    const structure: AdminConfiguratorStructure = {
+      fields: {
+        jobs: {
+          fields: {
+            police: { kind: 'value', valueType: 'boolean' },
+          },
+          kind: 'table',
+          mutableKeys: true,
+          template: { kind: 'value', valueType: 'boolean' },
+        },
+        range: {
+          items: [
+            { kind: 'value', valueType: 'number' },
+            { kind: 'value', valueType: 'number' },
+          ],
+          kind: 'list',
+          template: { kind: 'value', valueType: 'number' },
+        },
+      },
+      kind: 'table',
+    }
+
+    expect(blankFromConfiguratorStructure(structure)).toEqual({
+      jobs: { police: false },
+      range: [0, 0],
+    })
   })
 })

--- a/frontend/testserver/configurator-fixture.cjs
+++ b/frontend/testserver/configurator-fixture.cjs
@@ -542,6 +542,25 @@ function buildStructure(value, scope, path) {
   }
   if (
     scope === 'config' &&
+    /^Radio\.LockedChannels\.\d+\.jobs$/.test(path) &&
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value)
+  ) {
+    return {
+      fields: Object.fromEntries(
+        Object.entries(value).map(([key, child]) => [
+          key,
+          buildStructure(child, scope, `${path}.${key}`),
+        ]),
+      ),
+      kind: 'table',
+      mutableKeys: true,
+      template: { kind: 'value', valueType: 'boolean' },
+    }
+  }
+  if (
+    scope === 'config' &&
     path === 'Companies.Definitions' &&
     value !== null &&
     typeof value === 'object' &&

--- a/frontend/testserver/configurator-fixture.test.ts
+++ b/frontend/testserver/configurator-fixture.test.ts
@@ -193,6 +193,29 @@ describe('admin configurator fixture', () => {
     })
   })
 
+  it('allows custom jobs in locked radio channel entries', () => {
+    const radio = loadConfiguratorSections()
+      .flatMap((section) => section.fields)
+      .find((field) => field.path === 'Radio')
+    const lockedChannels = radio?.structure?.fields?.LockedChannels
+    const jobs = lockedChannels?.items?.[0]?.fields?.jobs
+
+    expect(jobs).toMatchObject({
+      fields: {
+        ambulance: { kind: 'value', valueType: 'boolean' },
+        police: { kind: 'value', valueType: 'boolean' },
+      },
+      kind: 'table',
+      mutableKeys: true,
+      template: { kind: 'value', valueType: 'boolean' },
+    })
+    expect(lockedChannels?.template?.fields?.jobs).toMatchObject({
+      kind: 'table',
+      mutableKeys: true,
+      template: { kind: 'value', valueType: 'boolean' },
+    })
+  })
+
   it('publishes fixed schemas for every empty configurable collection', () => {
     const fields = loadConfiguratorSections().flatMap(
       (section) => section.fields,

--- a/sky_phone/source/server/phone_configurator.lua
+++ b/sky_phone/source/server/phone_configurator.lua
@@ -637,6 +637,21 @@ local function build_structure(value, scope, path)
     if scope == "config" and path == "Phone.Keybind" then
         return { kind = "optionalString" }
     end
+    if scope == "config"
+        and path:match("^Radio%.LockedChannels%.%d+%.jobs$")
+        and value_type == "table"
+    then
+        local fields = {}
+        for key, child in pairs(value) do
+            fields[key] = build_structure(child, scope, path .. "." .. tostring(key))
+        end
+        return {
+            fields = fields,
+            kind = "table",
+            mutableKeys = true,
+            template = { kind = "value", valueType = "boolean" },
+        }
+    end
     if scope == "config" and path == "Companies.Definitions" and value_type == "table" then
         local keys = {}
         for key in pairs(value) do


### PR DESCRIPTION
## Summary

Allow administrators to add custom jobs to Radio locked-channel rules and make newly added locked-channel rows saveable.

No linked issue.

## Root cause and approach

The radio runtime already accepted arbitrary job names, but the Phone Configurator inferred each nested `jobs` map as a fixed table. The generic “Add row” path also cloned an existing row before consulting the schema, which reduced required nested arrays such as `range` to `[]` and caused server-side `invalid_value` rejection.

Publish locked-channel job maps as mutable boolean-key tables and initialize structured list rows from their schema template.

## Changes

- expose `Radio.LockedChannels.*.jobs` as mutable boolean keys in server and preview schemas
- seed new locked-channel rows from the configurator schema so both range slots remain present
- add fixture, default-generation, and editor contract coverage

## Compatibility and migrations

None. Existing configuration, SQL payloads, framework behavior, and public APIs remain compatible.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [x] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes.
- [x] I ran a production frontend build for frontend changes.
- [ ] I tested affected Lua/native behavior with experimental OAL enabled, or marked the live runtime test as pending below.
- [x] I verified every changed NUI callback responds on every reachable path.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
vitest run testserver/configurator-fixture.test.ts src/utils/adminConfiguratorDefaults.test.ts src/components/AdminPanel.contract.test.ts
  3 files / 21 tests passed
vue-tsc --build
  passed
eslint .
  passed
vitest run
  231 files / 1,390 tests passed
node testserver/smoke.cjs
  71 browser endpoints verified
vite build && node build.cjs
  passed
```

## Runtime evidence

Static, type, lint, test, browser-mock, and production-build coverage passed. A restarted FiveM runtime test remains pending because the configured local deployment target is unavailable in this environment.

The required workspace commands were attempted:

```text
D:\Sky_Resources\build_frontend.bat
  blocked before modification: sky_dojjob/frontend/package.json is missing
D:\Sky_Resources\build_copy.bat -Resources sky_phone
  blocked before modification: configured local server [sky] target does not exist
```

## Security and architecture

- [x] Consequential actions remain server-authoritative and validate identity, permissions, ownership, limits, and payloads.
- [x] This change introduces no dependency, event, export, global, config, persistence, or fallback connection to another `sky_*` resource.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

No config, locale, or SQL migration is required. “Add row” creates a complete locked-channel entry; custom jobs are added inside its mutable `jobs` table.