### PR TITLE
FIX - require an authorized phone session before opening NUI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -826,7 +826,7 @@ function onMessage(event: MessageEvent<AppMessage>): void {
     hydratePhone(event.data.data as PhoneOpenPayload)
     void syncNavigationState().then(() => nuiCall('ui:opened'))
   } else if (event.data?.type === 'device:updated') {
-    hydratePhone(event.data.data as PhoneOpenPayload)
+    if (phone.isOpen) hydratePhone(event.data.data as PhoneOpenPayload)
   } else if (event.data?.type === 'app:close') {
     activitySuspended.value = false
     phone.endDeviceSession()

--- a/frontend/src/AppLifecycle.test.ts
+++ b/frontend/src/AppLifecycle.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
+
+import { createPinia, setActivePinia } from 'pinia'
+import ts from 'typescript'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePhoneStore, type PhoneOpenPayload } from '@/stores/phone'
+import { isTrustedRootMessageSource } from '@/utils/windowMessages'
+
+// Execute the production message and hydration handlers with real phone state,
+// without mounting every app, media player, and game in the phone shell.
+const source = readFileSync(new URL('./App.vue', import.meta.url), 'utf8')
+const script = source.match(/<script setup lang="ts">([\s\S]*?)<\/script>/)?.[1]
+if (!script) throw new Error('Phone root setup script was not found')
+const parsed = ts.createSourceFile(
+  'App.ts',
+  script,
+  ts.ScriptTarget.Latest,
+  true,
+)
+const handlers = parsed.statements
+  .filter(
+    (node) =>
+      ts.isFunctionDeclaration(node) &&
+      ['hydratePhone', 'onMessage'].includes(node.name?.text ?? ''),
+  )
+  .map((node) => node.getText(parsed))
+  .join('\n')
+const executable = ts.transpileModule(`${handlers}\nonMessage`, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022 },
+}).outputText
+
+const payload: PhoneOpenPayload = {
+  device: { data: {}, imei: '356938035643809', name: 'Phone', sim: null },
+  token: 'authorized-session',
+}
+
+describe('phone root device lifecycle', () => {
+  let onMessage: (event: { source: null; data: unknown }) => void
+
+  beforeEach(() => {
+    vi.stubGlobal('window', { matchMedia: () => ({ matches: false }) })
+    setActivePinia(createPinia())
+    const hydrate = vi.fn()
+    onMessage = runInNewContext(executable, {
+      window,
+      isTrustedRootMessageSource,
+      phone: usePhoneStore(),
+      configurePhoneNumberFormat: vi.fn(),
+      companies: { bindDeviceScope: vi.fn() },
+      appCatalog: { externalApps: [] },
+      notifications: { hydrate, hideDevicePreview: vi.fn() },
+      account: { hydrate },
+      appAuth: { hydrate },
+      notes: { hydrate },
+      memos: { hydrate },
+      clock: { hydrate },
+      games: { hydrate },
+      media: { hydrate },
+      appStore: { hydrate },
+      widgets: { hydrate },
+      route: { params: {} },
+      openHomeRequested: { value: false },
+      activitySuspended: { value: false },
+      syncNavigationState: () => Promise.resolve(),
+      nuiCall: vi.fn(),
+    }) as typeof onMessage
+  })
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('does not open a phone from an unsolicited device update', () => {
+    onMessage({ source: null, data: { type: 'device:updated', data: payload } })
+    expect(usePhoneStore().isOpen).toBe(false)
+    expect(usePhoneStore().deviceSessionToken).toBeNull()
+  })
+
+  it('keeps a closed session closed when an earlier update arrives late', () => {
+    onMessage({ source: null, data: { type: 'app:open', data: payload } })
+    expect(usePhoneStore().isOpen).toBe(true)
+    onMessage({ source: null, data: { type: 'app:close' } })
+    onMessage({ source: null, data: { type: 'device:updated', data: payload } })
+    expect(usePhoneStore().isOpen).toBe(false)
+    expect(usePhoneStore().deviceSessionToken).toBeNull()
+  })
+
+  it('continues to hydrate an open phone', () => {
+    onMessage({ source: null, data: { type: 'app:open', data: payload } })
+    onMessage({
+      source: null,
+      data: {
+        type: 'device:updated',
+        data: {
+          ...payload,
+          device: { ...payload.device, name: 'Updated phone' },
+        },
+      },
+    })
+    expect(usePhoneStore().isOpen).toBe(true)
+    expect(usePhoneStore().device?.name).toBe('Updated phone')
+  })
+})

--- a/sky_phone/source/client/main.lua
+++ b/sky_phone/source/client/main.lua
@@ -2,6 +2,7 @@ SkyPhoneClient = {}
 
 local is_open = false
 local open_requested = false
+local device_open_authorized = false
 local open_without_focus = false
 local device_payload = nil
 local equipped_phone_number = nil
@@ -189,6 +190,7 @@ local function close_phone(close_device_session)
     local was_requested = open_requested
     local was_open = is_open
     open_requested = false
+    device_open_authorized = false
     open_without_focus = false
     TriggerEvent("sky_phone:animation:phone", false)
     is_open = false
@@ -397,7 +399,7 @@ RegisterNUICallback("ui:ready", function(data, cb)
     Bridge.Debug("debug", "[sky_phone] NUI reported ready.", { always = true })
     send_phone_tone_catalog()
     SkyPhoneApps.SendCatalog()
-    if open_requested and device_payload then
+    if device_open_authorized and device_payload then
         send_open_message()
     end
     if admin_panel_open then
@@ -425,10 +427,10 @@ RegisterNUICallback("ui:opened", function(data, cb)
         cb({ success = false, error = "invalid_request" })
         return
     end
-    if not open_requested or not device_payload then
+    if not device_open_authorized or not device_payload then
         Bridge.Debug(
             "warn",
-            "[sky_phone] Ignored a NUI open confirmation without a pending device open.",
+            "[sky_phone] Ignored a NUI open confirmation without an authorized device open.",
             { always = true }
         )
         SendNUIMessage({ type = "app:close" })
@@ -510,6 +512,7 @@ RegisterNetEvent("sky_phone:device:open", function(data)
         Bridge.Debug("error", "[sky_phone] Rejected invalid device open data.")
         if not is_open then
             open_requested = false
+            device_open_authorized = false
             open_without_focus = false
         end
         return
@@ -525,6 +528,7 @@ RegisterNetEvent("sky_phone:device:open", function(data)
     device_payload = data
     update_equipped_phone_number(data)
     open_requested = true
+    device_open_authorized = true
     if is_open then
         SkyPhoneApps.SendCatalog()
         SendNUIMessage({ type = "device:updated", data = data })
@@ -536,6 +540,13 @@ end)
 RegisterNetEvent("sky_phone:device:updated", function(data)
     if type(data) ~= "table" or type(data.device) ~= "table" or type(data.device.imei) ~= "string" then
         Bridge.Debug("error", "[sky_phone] Rejected invalid device update data.")
+        return
+    end
+    if not device_open_authorized or not device_payload
+        or data.device.imei ~= device_payload.device.imei
+        or data.token ~= device_payload.token
+    then
+        Bridge.Debug("debug", "[sky_phone] Ignored a device update outside its authorized session.")
         return
     end
     apply_disabled_apps(data)
@@ -556,6 +567,7 @@ end)
 RegisterNetEvent("sky_phone:device:error", function(error_code)
     if not is_open then
         open_requested = false
+        device_open_authorized = false
         open_without_focus = false
         open_home_requested = false
     end
@@ -580,6 +592,7 @@ AddEventHandler("onResourceStop", function(resource_name)
 
     is_open = false
     open_requested = false
+    device_open_authorized = false
     open_without_focus = false
     admin_panel_open = false
 

--- a/tests/client_phone_lifecycle.lua
+++ b/tests/client_phone_lifecycle.lua
@@ -1,0 +1,152 @@
+local function new_client()
+    local net_events, nui_callbacks, messages = {}, {}, {}
+    local focused = false
+    local noop = function() end
+    local locale = { Controls = {}, DeviceErrors = { default = "Phone unavailable" }, Nui = {} }
+
+    Config = {
+        Bridge = { Locale = "en" },
+        Phone = { Keybind = false, DevelopmentCommand = false },
+        TestData = { Enabled = false },
+        AdminPanel = { Enabled = false },
+    }
+    Locales = { en = locale }
+    SkyPhoneLocales = { Resolve = function() return locale, "en" end }
+    Bridge = {
+        Debug = noop,
+        Framework = { Notify = noop },
+        Callbacks = {
+            Trigger = function(name)
+                if name == "sky_phone:device:open-request" then
+                    return coroutine.yield("awaiting_inventory")
+                end
+                return { success = true, data = {} }
+            end,
+        },
+    }
+    SkyPhoneApps = { SendCatalog = noop, SetPhoneOpen = noop }
+    SkyPhoneCalls = { IsActive = function() return false end, ReplayNui = noop, Reset = noop }
+    SkyPhoneSimPicker = { ReplayNui = noop, Reset = noop }
+    SkyPhoneFocus = {
+        SetPhone = function(value) focused = value end,
+        BeginNuiHydration = noop,
+        Reapply = noop,
+        Reset = noop,
+    }
+    RegisterNetEvent = function(name, callback) net_events[name] = callback end
+    RegisterNUICallback = function(name, callback) nui_callbacks[name] = callback end
+    SendNUIMessage = function(message) messages[#messages + 1] = message end
+    RegisterCommand, RegisterKeyMapping, AddEventHandler, TriggerEvent, CreateThread = noop, noop, noop, noop, noop
+
+    dofile("sky_phone/source/client/main.lua")
+
+    local client = { events = net_events, messages = messages }
+    function client.nui(name, data)
+        local response
+        nui_callbacks[name](data or {}, function(result) response = result end)
+        assert(response, "NUI callbacks must always respond")
+        return response
+    end
+    function client.take_messages(message_type)
+        local found = {}
+        for index = #messages, 1, -1 do
+            if messages[index].type == message_type then
+                found[#found + 1] = table.remove(messages, index)
+            end
+        end
+        return found
+    end
+    function client.authorize(payload)
+        net_events["sky_phone:device:open"](payload)
+        assert(client.nui("ui:opened").success)
+        assert(SkyPhoneClient.GetState().open and focused)
+        client.take_messages("app:open")
+    end
+    return client
+end
+
+local function device(token, number)
+    return {
+        token = token,
+        device = {
+            imei = "356938035643809",
+            sim = { number = number or "5551234567" },
+        },
+    }
+end
+
+local failures = 0
+local function test(name, callback)
+    local success, message = pcall(callback)
+    if success then
+        print("PASS " .. name)
+    else
+        failures = failures + 1
+        print("FAIL " .. name .. ": " .. tostring(message))
+    end
+end
+
+test("late device updates cannot revive a closed phone", function()
+    local client = new_client()
+    client.authorize(device("old-session"))
+    SkyPhoneClient.Toggle(false)
+    client.events["sky_phone:device:updated"](device("old-session"))
+    assert(#client.take_messages("device:updated") == 0, "closed phones must not forward stale hydration")
+    assert(not SkyPhoneClient.GetState().open)
+end)
+
+test("late updates cannot restore an invalidated device", function()
+    local client = new_client()
+    client.authorize(device("removed-device"))
+    client.events["sky_phone:device:invalidated"]()
+    client.events["sky_phone:device:updated"](device("removed-device"))
+    assert(#client.take_messages("device:updated") == 0, "invalidated device updates must be discarded")
+    assert(SkyPhoneClient.GetState().phoneNumber == nil)
+end)
+
+test("a previous session cannot overwrite the active phone", function()
+    local client = new_client()
+    client.authorize(device("new-session"))
+    client.events["sky_phone:device:updated"](device("old-session", "5559999999"))
+    assert(#client.take_messages("device:updated") == 0, "updates must belong to the current session")
+    assert(SkyPhoneClient.GetState().phoneNumber == "5551234567")
+end)
+
+test("NUI reload waits for inventory authorization instead of replaying the last phone", function()
+    local client = new_client()
+    client.authorize(device("old-session"))
+    SkyPhoneClient.Toggle(false)
+    local request = coroutine.create(function() return SkyPhoneClient.Toggle(true) end)
+    local resumed, state = coroutine.resume(request)
+    assert(resumed and state == "awaiting_inventory")
+    assert(client.nui("ui:ready", { protocolVersion = 1 }).success)
+    assert(#client.take_messages("app:open") == 0, "pending inventory checks must not authorize cached devices")
+    assert(not client.nui("ui:opened").success, "NUI cannot confirm an unauthorized opening")
+    client.events["sky_phone:device:error"]("phone_required")
+    local completed, opened = coroutine.resume(request, { success = false, error = "phone_required" })
+    assert(completed and opened == false)
+    assert(not SkyPhoneClient.GetState().open)
+end)
+
+test("authorized opens survive a NUI reload before the first confirmation", function()
+    local client = new_client()
+    client.events["sky_phone:device:open"](device("valid-session"))
+    client.take_messages("app:open")
+    assert(client.nui("ui:ready", { protocolVersion = 1 }).success)
+    assert(#client.take_messages("app:open") == 1)
+    assert(client.nui("ui:opened").success)
+    assert(SkyPhoneClient.GetState().open)
+end)
+
+test("current device updates and server-authorized device switching still work", function()
+    local client = new_client()
+    client.authorize(device("valid-session"))
+    client.events["sky_phone:device:updated"](device("valid-session", "5552222222"))
+    assert(#client.take_messages("device:updated") == 1)
+    assert(SkyPhoneClient.GetState().phoneNumber == "5552222222")
+    client.events["sky_phone:device:open"](device("next-session", "5553333333"))
+    assert(#client.take_messages("device:updated") == 1)
+    assert(SkyPhoneClient.GetState().phoneNumber == "5553333333")
+end)
+
+assert(failures == 0, ("%s phone lifecycle tests failed"):format(failures))


### PR DESCRIPTION
## Summary

Keep the phone closed when a delayed device update arrives after closing it or losing the item. NUI reloads now wait for the server to authorize an opening instead of replaying a previously used device while an inventory check is still pending.

## Root cause and approach

`device:updated` called the same frontend hydration function as `app:open`, which sets `phone.isOpen = true`. The Lua client also used `open_requested` for both pending requests and authorized opens, allowing cached device data to be replayed during NUI hydration. Track authorization separately, reject updates outside the active device session, and hydrate frontend updates only while the phone is open.

## Changes

- Require an authorized device before replaying NUI state or accepting the open confirmation.
- Match device updates to the current IMEI and session token; clear authorization on close, invalidation, failed opening, and resource stop.
- Add executable Lua and frontend regressions for delayed updates, invalidation, pending inventory checks, NUI reloads, and authorized device switching.

## Compatibility and migrations

No configuration, locale, SQL, or public API migrations. The Hex/ESX inventory adapter remains unchanged. Normal authorized opens, active-device updates, and server-authorized device switching remain supported.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [x] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes.
- [x] I ran a production frontend build for frontend changes.
- [x] I tested affected Lua/native behavior with experimental OAL enabled, or marked the live runtime test as pending below.
- [x] I verified every changed NUI callback responds on every reachable path.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
node .github/scripts/validate-repository.mjs: passed
pnpm lint: passed
pnpm typecheck and production build through build_frontend.bat: passed
Targeted Vitest run: 62 tests passed across 6 files
pnpm test: 1,418 tests passed across 236 files; 71 browser data endpoints verified
lua54 tests/client_phone_lifecycle.lua: all 6 scenarios passed
Lua inventory_bridges, inventory_extended_bridges, client_focus,
provider_client_compat, and client_navigation scripts: passed
Hex adapter item-count transitions (present, removed, string zero, reacquired): passed
ESLint/Prettier for changed frontend files and git diff --check: passed
build_copy.bat: ESX and Qbox copies passed, all 464 files matched by SHA-256
```

## Runtime evidence

Before the fix, four new Lua scenarios and two new frontend scenarios reproduced the defect; they pass with this change. The frontend regressions execute the production handlers from `App.vue` with real Pinia phone state. This is source/build/deployment evidence. A restarted FiveM test with OAL on the affected Hex server remains pending; no claim of customer runtime confirmation is made.

Official Cfx documentation and source were inspected at `citizenfx/fivem` revision `0d8a2a6f78a9922445d8930305af82a7b1826980`: `data/shared/citizen/scripting/lua/scheduler.lua` (`RegisterNetEvent`, `RegisterNUICallback`, `SendNUIMessage`) and `code/components/nui-resources/src/ResourceUIScripting.cpp` (`SEND_NUI_MESSAGE`, `sendMessageToFrame`). No GTA engine native or per-frame work is added.

## Security and architecture

- [x] Consequential actions remain server-authoritative and validate identity, permissions, ownership, limits, and payloads.
- [x] This change introduces no dependency, event, export, global, config, persistence, or fallback connection to another `sky_*` resource.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

On a Hex test server, check opening with no item, normal opening after receiving one, closing and removing it, and re-opening after receiving it again. Also check a delayed device update after close and a NUI reload while the inventory request is pending. The phone should only become visible and take focus after server authorization.
