### PR TITLE
ADD - synchronize CityWarn map blips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
             luac5.4 -p "$file"
           done < <(find sky_phone tests -type f -name '*.lua' -print0)
 
+      - name: Test CityWarn blip lifecycle
+        run: |
+          lua5.4 tests/client_citywarn.lua
+          lua5.4 tests/server_citywarn.lua
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest

--- a/sky_phone/README.md
+++ b/sky_phone/README.md
@@ -606,6 +606,22 @@ pnpm build
 
 ## Troubleshooting
 
+### CityWarn map blips
+
+Active CityWarn warnings with coordinates appear on the GTA map and minimap for
+all players, including with the phone closed. Radius warnings include a translucent
+area; district warnings with coordinates use a point marker. City-wide warnings
+and districts without coordinates remain available in the phone app without an
+invented map location. The existing in-app map and its personal filters still work;
+those filters do not hide the public GTA warning blips.
+
+Publishing or updating a warning triggers a server sync. Resolving it removes its
+blips immediately, and expiration removes them locally even if a server request
+times out. Joining or restarting the resource restores active warnings, with a
+30-second reconciliation for missed events and a 5-second retry after failures.
+Disabling `Config.CityWarn.Enabled` through the Phone Configurator or stopping the
+resource removes the blips. No additional configuration or SQL migration is needed.
+
 ### The phone item does nothing
 
 - Confirm the framework and inventory are supported and started first.

--- a/sky_phone/fxmanifest.lua
+++ b/sky_phone/fxmanifest.lua
@@ -43,6 +43,7 @@ client_scripts {
     'source/client/sim.lua',
     'source/client/camera.lua',
     'source/client/location.lua',
+    'source/client/citywarn.lua',
     'source/client/weather.lua',
     'source/client/garage.lua',
     'source/client/skyride.lua',

--- a/sky_phone/source/client/citywarn.lua
+++ b/sky_phone/source/client/citywarn.lua
@@ -1,0 +1,203 @@
+local blips = {}
+local sync_requested = true
+local change_version = 0
+local stopped = false
+local severity_colours = { information = 3, warning = 5, danger = 1, extreme = 27 }
+
+local function elapsed(since)
+    return (GetGameTimer() - since) & 0xffffffff
+end
+
+local function enabled()
+    return Config.CityWarn and Config.CityWarn.Enabled
+end
+
+local function remove_handle(handle)
+    if handle and DoesBlipExist(handle) then
+        RemoveBlip(handle)
+    end
+end
+
+local function remove_alert(id)
+    local entry = blips[id]
+    if entry then
+        remove_handle(entry.point)
+        remove_handle(entry.radius)
+        blips[id] = nil
+    end
+end
+
+local function clear_blips()
+    for id in pairs(blips) do
+        remove_alert(id)
+    end
+end
+
+local function finite_number(value, minimum, maximum)
+    return type(value) == "number" and value == value and value >= minimum and value <= maximum
+end
+
+local function valid_alert(alert)
+    return type(alert) == "table" and type(alert.id) == "string" and #alert.id > 0 and #alert.id <= 64
+        and type(alert.title) == "string" and severity_colours[alert.severity] ~= nil
+        and finite_number(alert.x, -10000, 10000) and finite_number(alert.y, -10000, 10000)
+        and finite_number(alert.remainingMs, 0, 604800000)
+        and (alert.radius == nil or finite_number(alert.radius, 1, 50000))
+end
+
+local function set_name(handle, title)
+    local locale = SkyPhoneLocales.Resolve(Config.Bridge.Locale).Nui.Apps.citywarn
+    -- GTA interprets tildes as formatting. Keep each text component within 99 bytes,
+    -- without cutting a UTF-8 character or losing long, localized warning titles.
+    local label = (locale.name .. ": " .. title):gsub("~", "")
+    BeginTextCommandSetBlipName("STRING")
+    local first = 1
+    while first <= #label do
+        local last = math.min(first + 98, #label)
+        while last < #label and label:byte(last + 1) >= 128 and label:byte(last + 1) < 192 do
+            last = last - 1
+        end
+        AddTextComponentSubstringPlayerName(label:sub(first, last))
+        first = last + 1
+    end
+    EndTextCommandSetBlipName(handle)
+end
+
+local function update_alert(alert, started_at)
+    local entry = blips[alert.id] or {}
+    blips[alert.id] = entry
+
+    if not entry.point or not DoesBlipExist(entry.point) then
+        entry.point = AddBlipForCoord(alert.x + 0.0, alert.y + 0.0, 0.0)
+        if not entry.point or not DoesBlipExist(entry.point) then
+            remove_alert(alert.id)
+            return false
+        end
+        SetBlipSprite(entry.point, 161)
+        SetBlipScale(entry.point, 0.9)
+        SetBlipDisplay(entry.point, 2)
+        SetBlipAsShortRange(entry.point, false)
+    end
+    SetBlipCoords(entry.point, alert.x + 0.0, alert.y + 0.0, 0.0)
+    SetBlipColour(entry.point, severity_colours[alert.severity])
+    set_name(entry.point, alert.title)
+
+    if entry.radius_size ~= alert.radius then
+        remove_handle(entry.radius)
+        entry.radius = nil
+    end
+    if alert.radius then
+        if not entry.radius or not DoesBlipExist(entry.radius) then
+            entry.radius = AddBlipForRadius(alert.x + 0.0, alert.y + 0.0, 0.0, alert.radius + 0.0)
+            if not entry.radius or not DoesBlipExist(entry.radius) then
+                remove_alert(alert.id)
+                return false
+            end
+            SetBlipAlpha(entry.radius, 80)
+        end
+        SetBlipCoords(entry.radius, alert.x + 0.0, alert.y + 0.0, 0.0)
+        SetBlipColour(entry.radius, severity_colours[alert.severity])
+    end
+    entry.radius_size = alert.radius
+    entry.started_at = started_at
+    entry.remaining_ms = alert.remainingMs
+    return true
+end
+
+local function apply_snapshot(alerts, started_at)
+    local seen = {}
+    local error_code
+    for _, alert in ipairs(alerts) do
+        if not valid_alert(alert) then
+            error_code = "invalid_snapshot"
+        elseif elapsed(started_at) < alert.remainingMs then
+            seen[alert.id] = true
+            if not update_alert(alert, started_at) then
+                error_code = "blip_creation_failed"
+            end
+        end
+    end
+    for id in pairs(blips) do
+        if not seen[id] then
+            remove_alert(id)
+        end
+    end
+    return error_code
+end
+
+local function request_sync()
+    change_version = change_version + 1
+    sync_requested = true
+end
+
+RegisterNetEvent("sky_phone:citywarn:changed", function(data)
+    if source ~= 65535 or type(data) ~= "table" then
+        return
+    end
+    -- Fetch authoritative state instead of allowing an older event to recreate
+    -- a resolved alert. Existing NUI notifications keep their own event handler.
+    request_sync()
+    if data.kind == "resolved" and type(data.alertId) == "string" then
+        remove_alert(data.alertId)
+    end
+end)
+
+AddEventHandler("sky_phone:configurator:updated", function()
+    request_sync()
+    if not enabled() then
+        clear_blips()
+    end
+end)
+
+AddEventHandler("onResourceStop", function(resource_name)
+    if resource_name == GetCurrentResourceName() then
+        stopped = true
+        clear_blips()
+    end
+end)
+
+CreateThread(function()
+    local last_attempt = GetGameTimer()
+    local retry_after = 0
+    local last_error
+    while not stopped do
+        if enabled() and (sync_requested or elapsed(last_attempt) >= retry_after) then
+            sync_requested = false
+            local version = change_version
+            local started_at = GetGameTimer()
+            local response = Bridge.Callbacks.Trigger("sky_phone:citywarn:blips", {})
+            last_attempt = GetGameTimer()
+            retry_after = 5000
+            if not stopped and enabled() and version == change_version then
+                local error_code
+                if response and response.success and type(response.data) == "table"
+                    and type(response.data.alerts) == "table"
+                then
+                    error_code = apply_snapshot(response.data.alerts, started_at)
+                    if not error_code then
+                        retry_after = 30000
+                    end
+                else
+                    error_code = response and response.error or "request_failed"
+                end
+                if error_code and error_code ~= last_error then
+                    Bridge.Debug("warn", "[sky_phone] CityWarn blip sync failed: %s.", tostring(error_code))
+                end
+                last_error = error_code
+            end
+        end
+        Wait(1000)
+    end
+end)
+
+-- Expiry must continue even while a server callback is waiting or timing out.
+CreateThread(function()
+    while not stopped do
+        for id, entry in pairs(blips) do
+            if not enabled() or elapsed(entry.started_at) >= entry.remaining_ms then
+                remove_alert(id)
+            end
+        end
+        Wait(1000)
+    end
+end)

--- a/sky_phone/source/server/citywarn.lua
+++ b/sky_phone/source/server/citywarn.lua
@@ -348,7 +348,68 @@ local function validate_area(data, access)
     }
 end
 
+local blip_cache
+local blip_version = 0
+
+local function invalidate_blips()
+    blip_cache = nil
+    blip_version = blip_version + 1
+end
+
+AddEventHandler("sky_phone:configurator:serverUpdated", function()
+    config = Config.CityWarn
+    invalidate_blips()
+end)
+
+-- Population warnings are public, including while a phone is closed. This
+-- read-only endpoint deliberately does not require an open device session.
+Bridge.Callbacks.Register("sky_phone:citywarn:blips", function(source)
+    if not SkyPhone.AllowOperation(source, "citywarn_blips", 60, 60) then
+        return { success = false, error = "rate_limited" }
+    end
+    if not config.Enabled then
+        return { success = true, data = { alerts = {} } }
+    end
+
+    if not blip_cache or ((GetGameTimer() - blip_cache.created_at) & 0xffffffff) >= 5000 then
+        local version = blip_version
+        local started_at = GetGameTimer()
+        local rows = Bridge.Database.Query([[
+            SELECT `id`, `title`, `severity`, `area_type`, `center_x`, `center_y`, `radius`,
+                TIMESTAMPDIFF(SECOND, NOW(), `expires_at`) AS `remaining_seconds`
+            FROM `sky_phone_citywarn_alerts`
+            WHERE `status` = 'active' AND `expires_at` > NOW()
+                AND `area_type` IN ('radius', 'district')
+                AND `center_x` IS NOT NULL AND `center_y` IS NOT NULL
+        ]], {})
+        -- A publication/resolution can complete while the database query yields.
+        if version ~= blip_version then
+            return { success = false, error = "revision_conflict" }
+        end
+        blip_cache = { created_at = started_at, rows = rows }
+    end
+
+    local age = (GetGameTimer() - blip_cache.created_at) & 0xffffffff
+    local alerts = {}
+    for _, row in ipairs(blip_cache.rows) do
+        local remaining_ms = (tonumber(row.remaining_seconds) or 0) * 1000 - age
+        if remaining_ms > 0 then
+            alerts[#alerts + 1] = {
+                id = row.id,
+                title = row.title,
+                severity = row.severity,
+                x = tonumber(row.center_x),
+                y = tonumber(row.center_y),
+                radius = row.area_type == "radius" and tonumber(row.radius) or nil,
+                remainingMs = remaining_ms,
+            }
+        end
+    end
+    return { success = true, data = { alerts = alerts } }
+end)
+
 local function broadcast(kind, alert)
+    invalidate_blips()
     TriggerClientEvent("sky_phone:citywarn:changed", -1, {
         alert = alert,
         alertId = alert.id,

--- a/tests/client_citywarn.lua
+++ b/tests/client_citywarn.lua
@@ -1,0 +1,236 @@
+local function new_client()
+    local test = { now = 0, threads = {}, events = {}, handles = {}, requests = 0, logs = {} }
+    local env = setmetatable({}, { __index = _G })
+    env.Config = { CityWarn = { Enabled = true }, Bridge = { Locale = "en" } }
+    env.SkyPhoneLocales = { Resolve = function()
+        return { Nui = { Apps = { citywarn = { name = "CityWarn" } } } }
+    end }
+    env.GetGameTimer = function() return test.now end
+    env.GetCurrentResourceName = function() return "sky_phone" end
+    env.RegisterNetEvent = function(name, callback) test.events[name] = callback end
+    env.AddEventHandler = env.RegisterNetEvent
+    env.CreateThread = function(callback)
+        test.threads[#test.threads + 1] = { coroutine = coroutine.create(callback), wake = test.now }
+    end
+    env.Wait = function(ms) return coroutine.yield(ms) end
+    env.Bridge = {
+        Debug = function(_, _, error_code) test.logs[#test.logs + 1] = error_code end,
+        Callbacks = { Trigger = function(name, data)
+            assert(name == "sky_phone:citywarn:blips" and type(data) == "table")
+            test.requests = test.requests + 1
+            if test.block then return coroutine.yield("request") end
+            return test.response
+        end },
+    }
+    local function coordinates(x, y, z)
+        assert(math.type(x) == "float" and math.type(y) == "float" and math.type(z) == "float",
+            "OAL coordinates must be separate floats")
+        return { x = x, y = y, z = z }
+    end
+    local function create(kind, x, y, z, radius)
+        if test.fail == kind then return 0 end
+        local handle = #test.handles + 1
+        test.handles[handle] = { kind = kind, coords = coordinates(x, y, z), size = radius, exists = true }
+        return handle
+    end
+    env.AddBlipForCoord = function(x, y, z) return create("point", x, y, z) end
+    env.AddBlipForRadius = function(x, y, z, radius)
+        assert(math.type(radius) == "float", "OAL radius must be a float")
+        return create("radius", x, y, z, radius)
+    end
+    env.DoesBlipExist = function(handle)
+        return test.handles[handle] and test.handles[handle].exists and 1 or nil
+    end
+    env.RemoveBlip = function(handle)
+        assert(env.DoesBlipExist(handle), "only live, owned handles may be removed")
+        test.handles[handle].exists = false
+    end
+    env.SetBlipCoords = function(handle, x, y, z) test.handles[handle].coords = coordinates(x, y, z) end
+    for _, property in ipairs({ "Sprite", "Scale", "Display", "AsShortRange", "Alpha", "Colour" }) do
+        env["SetBlip" .. property] = function(handle, value)
+            assert(env.DoesBlipExist(handle))
+            test.handles[handle][property] = value
+        end
+    end
+    local components
+    env.BeginTextCommandSetBlipName = function(label)
+        assert(label == "STRING")
+        components = {}
+    end
+    env.AddTextComponentSubstringPlayerName = function(value)
+        assert(#value <= 99 and utf8.len(value), "text components must contain bounded, intact UTF-8")
+        components[#components + 1] = value
+    end
+    env.EndTextCommandSetBlipName = function(handle) test.handles[handle].name = table.concat(components) end
+
+    function test.resume(thread, ...)
+        local success, delay = coroutine.resume(thread.coroutine, ...)
+        assert(success, delay)
+        thread.wake = type(delay) == "number" and test.now + delay or math.huge
+        if delay == "request" then test.pending = thread end
+    end
+    function test.run()
+        for _, thread in ipairs(test.threads) do
+            if thread.wake <= test.now and coroutine.status(thread.coroutine) ~= "dead" then
+                test.resume(thread)
+            end
+        end
+    end
+    function test.advance(ms)
+        local target = test.now + ms
+        while test.now < target do
+            test.now = math.min(target, test.now + 1000)
+            test.run()
+        end
+    end
+    function test.snapshot(alerts) test.response = { success = true, data = { alerts = alerts } } end
+    function test.send(kind, id, origin)
+        env.source = origin or 65535
+        test.events["sky_phone:citywarn:changed"]({ kind = kind, alertId = id })
+    end
+    function test.count()
+        local count = 0
+        for _, handle in ipairs(test.handles) do if handle.exists then count = count + 1 end end
+        return count
+    end
+    function test.configure(enabled)
+        env.Config.CityWarn.Enabled = enabled
+        test.events["sky_phone:configurator:updated"]()
+    end
+    assert(loadfile("sky_phone/source/client/citywarn.lua", "t", env))()
+    return test
+end
+
+local function alert(overrides)
+    local value = { id = "alert-1", title = "Police operation", severity = "danger", x = 100, y = 200,
+        radius = 500, remainingMs = 60000 }
+    for key, item in pairs(overrides or {}) do value[key] = item end
+    return value
+end
+
+local client = new_client()
+client.snapshot({ alert() })
+client.run()
+assert(client.count() == 2 and client.requests == 1, "join/restart must restore blips without opening NUI")
+assert(client.handles[1].Display == 2 and client.handles[1].AsShortRange == false)
+assert(client.handles[1].Colour == 1 and client.handles[2].Alpha == 80)
+assert(client.handles[1].name == "CityWarn: Police operation")
+client.send("published", "alert-1")
+client.send("published", "alert-1")
+client.advance(1000)
+assert(client.count() == 2 and #client.handles == 2, "duplicate events must not duplicate blips")
+
+local long_title = string.rep("Ä", 120)
+client.snapshot({ alert({ x = -50, y = 0, radius = 800, severity = "extreme", title = "~r~" .. long_title }) })
+client.send("update", "alert-1")
+client.advance(1000)
+assert(client.count() == 2 and #client.handles == 3 and not client.handles[2].exists)
+assert(client.handles[1].coords.x == -50 and client.handles[1].Colour == 27)
+assert(client.handles[3].size == 800 and client.handles[3].Colour == 27)
+assert(client.handles[1].name == "CityWarn: r" .. long_title, "names must strip GTA directives and preserve UTF-8")
+
+local district = alert()
+district.radius = nil
+client.snapshot({ district })
+client.send("update", "alert-1")
+client.advance(1000)
+assert(client.count() == 1 and client.handles[1].exists, "district conversion must remove only the radius")
+client.send("resolved", "alert-1", 12)
+assert(client.count() == 1, "local events must not control public blips")
+client.snapshot({})
+client.send("resolved", "alert-1")
+assert(client.count() == 0, "resolution must remove handles immediately")
+client.send("published", "alert-1")
+client.advance(1000)
+assert(client.count() == 0, "delayed publication must not resurrect a resolved alert")
+
+client.snapshot({ alert() })
+client.advance(30000)
+assert(client.count() == 2, "periodic snapshots must recover missed publications")
+client.snapshot({})
+client.advance(30000)
+assert(client.count() == 0, "periodic snapshots must recover missed removals")
+
+client = new_client()
+client.snapshot({ alert({ remainingMs = 3000 }) })
+client.run()
+client.block = true
+client.send("update", "alert-1")
+client.advance(1000)
+assert(client.pending)
+client.advance(2000)
+assert(client.count() == 0, "expiry must run while callbacks are blocked")
+client.resume(client.pending, { success = true, data = { alerts = { alert({ remainingMs = 1000 }) } } })
+assert(client.count() == 0, "network time must not extend expired warnings")
+
+client = new_client()
+client.block = true
+client.run()
+client.send("resolved", "alert-1")
+client.resume(client.pending, { success = true, data = { alerts = { alert() } } })
+assert(client.count() == 0, "a resolution during a request must invalidate its snapshot")
+client.block = false
+client.snapshot({})
+client.advance(1000)
+assert(client.requests == 2 and client.count() == 0)
+client.response = nil
+client.send("published", "alert-1")
+client.advance(1000)
+assert(client.logs[#client.logs] == "request_failed")
+client.snapshot({ alert() })
+client.advance(5000)
+assert(client.count() == 2, "failed bootstrap/callbacks must retry")
+
+client.configure(false)
+assert(client.count() == 0, "disabling CityWarn must immediately remove its blips")
+local requests = client.requests
+client.advance(30000)
+assert(client.requests == requests, "disabled CityWarn must not poll")
+client.configure(true)
+client.advance(1000)
+assert(client.count() == 2, "re-enabling CityWarn must restore active warnings")
+client.block = true
+client.send("update", "alert-1")
+client.advance(1000)
+client.configure(false)
+client.resume(client.pending, { success = true, data = { alerts = { alert() } } })
+assert(client.count() == 0, "in-flight responses must not revive disabled blips")
+
+client = new_client()
+client.fail = "radius"
+client.snapshot({ alert() })
+client.run()
+assert(client.count() == 0 and client.logs[1] == "blip_creation_failed", "partial creation must clean up and report failure")
+client.fail = nil
+client.advance(5000)
+assert(client.count() == 2, "failed natives must be retried")
+client.handles[#client.handles].exists = false
+client.advance(30000)
+assert(client.count() == 2, "missing native handles must be repaired")
+client.events.onResourceStop("another_resource")
+assert(client.count() == 2)
+client.block = true
+client.send("update", "alert-1")
+client.advance(1000)
+client.events.onResourceStop("sky_phone")
+client.resume(client.pending, { success = true, data = { alerts = { alert() } } })
+assert(client.count() == 0, "resource stop must remove owned blips and reject pending results")
+
+client = new_client()
+client.snapshot({ alert({ x = 0 / 0 }), alert({ x = math.huge }), alert({ y = 10001 }),
+    alert({ radius = -1 }), alert({ severity = "invalid" }), alert({ remainingMs = 0 }) })
+client.run()
+assert(client.count() == 0, "invalid coordinates, radii and expirations must never reach natives")
+assert(client.logs[1] == "invalid_snapshot", "invalid snapshots must remain visible in diagnostics")
+client.now = 0x7fffffff - 1000
+client.snapshot({ alert({ remainingMs = 3000 }) })
+client.send("published", "alert-1")
+client.run()
+assert(client.count() == 2)
+client.now = client.now - 0x100000000 + 3000
+for _, thread in ipairs(client.threads) do thread.wake = client.now end
+client.block = true
+client.run()
+assert(client.count() == 0, "expiry must survive signed GetGameTimer wraparound")
+
+print("CityWarn client lifecycle tests passed")

--- a/tests/server_citywarn.lua
+++ b/tests/server_citywarn.lua
@@ -1,0 +1,167 @@
+local callbacks, events, rows = {}, {}, {}
+local now, uuid_count, snapshot_queries = 0, 0, 0
+local allow_operation, allow_session, during_query = true, true, nil
+local broadcast
+
+Config = { CityWarn = {
+    Enabled = true, RequireDuty = true, PageSize = 1, MaximumActiveAlerts = 20,
+    TitleMaxLength = 120, BodyMaxLength = 2000, InstructionsMaxLength = 2000, UpdateMaxLength = 2000,
+    AreaLabelMaxLength = 120, MinimumRadius = 100, MaximumRadius = 10000,
+    DefaultDurationMinutes = 60, MaximumDurationMinutes = 1440,
+    RateLimits = { Read = 180, Write = 20 },
+    Publishers = { police = { MinimumGrade = 2, MaximumSeverity = "extreme", CityWide = true,
+        Categories = { "police" } } },
+} }
+
+local function database(sql, parameters)
+    if sql:find("TIMESTAMPDIFF", 1, true) then
+        snapshot_queries = snapshot_queries + 1
+        assert(not sql:find("LIMIT", 1, true), "blips must not be truncated to the app page size")
+        assert(sql:find("`status` = 'active'", 1, true) and sql:find("`expires_at` > NOW()", 1, true))
+        assert(sql:find("`area_type` IN ('radius', 'district')", 1, true))
+        assert(sql:find("`center_x` IS NOT NULL AND `center_y` IS NOT NULL", 1, true))
+        local result = {}
+        for _, row in pairs(rows) do
+            if row.status == "active" and row.expires_at_unix > now / 1000
+                and row.area_type ~= "city" and row.center_x and row.center_y
+            then
+                local copy = {}
+                for key, value in pairs(row) do copy[key] = value end
+                copy.remaining_seconds = row.expires_at_unix - math.floor(now / 1000)
+                result[#result + 1] = copy
+            end
+        end
+        if during_query then
+            local action = during_query
+            during_query = nil
+            action()
+        end
+        return result
+    elseif sql:find("SELECT COUNT(*)", 1, true) then
+        return { { count = 0 } }
+    elseif sql:find("SELECT UUID()", 1, true) then
+        uuid_count = uuid_count + 1
+        return { { id = ("00000000-0000-0000-0000-%012d"):format(uuid_count) } }
+    elseif sql:find("INSERT INTO `sky_phone_citywarn_alerts`", 1, true) then
+        rows[parameters[1]] = {
+            id = parameters[1], title = parameters[2], body = parameters[3], instructions = parameters[4],
+            category = parameters[5], severity = parameters[6], area_type = parameters[7], area_label = parameters[8],
+            center_x = parameters[9], center_y = parameters[10], radius = parameters[11],
+            source_label = parameters[13], author_name = parameters[15], status = "active", revision = 1,
+            starts_at_unix = 0, expires_at_unix = now / 1000 + parameters[16] * 60,
+            created_at_unix = 0, updated_at_unix = 0,
+        }
+        return 1
+    elseif sql:find("INSERT INTO `sky_phone_citywarn_updates`", 1, true) then
+        return 1
+    elseif sql:find("UPDATE `sky_phone_citywarn_alerts`", 1, true) then
+        local row = rows[parameters[1]]
+        assert(row and row.revision == parameters[2])
+        row.revision = row.revision + 1
+        if sql:find("'resolved'", 1, true) then row.status = "resolved" end
+        return 1
+    elseif sql:find("FROM `sky_phone_citywarn_updates`", 1, true) then
+        return {}
+    elseif sql:find("WHERE alert.`id` = ?", 1, true) then
+        return { rows[parameters[1]] }
+    end
+    error("Unexpected query: " .. sql)
+end
+
+Bridge = {
+    Database = { AfterMigration = function(_, callback) callback() end, Query = database },
+    Callbacks = { Register = function(name, callback) callbacks[name] = callback end },
+    Framework = {
+        GetJob = function() return { name = "police", label = "Police", grade = 3, onDuty = true } end,
+        GetIdentifier = function() return "test-author" end,
+        GetFirstname = function() return "Test" end,
+        GetLastname = function() return "Author" end,
+        GetPlayers = function() return { 1, 2 } end,
+    },
+}
+SkyPhone = {
+    AllowOperation = function(_, operation, maximum, window)
+        if operation == "citywarn_blips" then assert(maximum == 60 and window == 60) end
+        return allow_operation
+    end,
+    RequireSession = function()
+        if allow_session then return {} end
+        return nil, { success = false, error = "device_not_open" }
+    end,
+}
+function GetGameTimer() return now end
+function AddEventHandler(name, callback) events[name] = callback end
+function TriggerClientEvent(name, target, data)
+    assert(name == "sky_phone:citywarn:changed" and target == -1)
+    broadcast = data
+end
+
+dofile("sky_phone/source/server/citywarn.lua")
+local function snapshot() return callbacks["sky_phone:citywarn:blips"](1) end
+local function publish(area)
+    local result = callbacks["sky_phone:citywarn:publish"](1, {
+        title = "Test warning", body = "Avoid the area", instructions = "", durationMinutes = 1,
+        category = "police", severity = "danger",
+        area = area or { type = "radius", label = "Test area", centerX = 100, centerY = 200, radius = 500 },
+    })
+    assert(result.success)
+    return result.data.alert
+end
+
+allow_session = false
+assert(snapshot().success, "public blips must work without an open phone")
+local denied = callbacks["sky_phone:citywarn:publish"](1, {})
+assert(not denied.success and denied.error == "device_not_open", "publishing must still require a phone session")
+allow_session = true
+local first = publish()
+assert(broadcast.kind == "published" and broadcast.alertId == first.id)
+local state = snapshot().data.alerts
+assert(#state == 1 and state[1].radius == 500 and state[1].remainingMs == 60000,
+    "publishing must invalidate the previously empty cache")
+assert(state[1].body == nil and state[1].author_name == nil and state[1].updates == nil,
+    "the public snapshot must only expose fields needed for blips")
+local queries = snapshot_queries
+now = 2000
+state = snapshot().data.alerts
+assert(snapshot_queries == queries and state[1].remainingMs == 58000, "cache hits must age expiry without querying again")
+state[1].title = "Mutated response"
+assert(snapshot().data.alerts[1].title == "Test warning", "responses must not mutate the shared cache")
+
+local updated = callbacks["sky_phone:citywarn:update"](1, { id = first.id, revision = 1, message = "Update" })
+assert(updated.success and broadcast.kind == "update")
+snapshot()
+assert(snapshot_queries == queries + 1, "updates must invalidate the cache")
+local resolved = callbacks["sky_phone:citywarn:resolve"](1, { id = first.id, revision = 2, message = "All clear" })
+assert(resolved.success and broadcast.kind == "resolved")
+assert(#snapshot().data.alerts == 0, "resolved warnings must disappear from authoritative snapshots")
+
+publish()
+publish({ type = "district", label = "District", centerX = 0, centerY = 0 })
+publish({ type = "district", label = "Unlocated district" })
+publish({ type = "city", label = "Whole city" })
+state = snapshot().data.alerts
+assert(#state == 2, "all located alerts, including zero coordinates, must be returned beyond PageSize")
+local points, radii = 0, 0
+for _, item in ipairs(state) do
+    if item.radius then radii = radii + 1 else points = points + 1 end
+end
+assert(points == 1 and radii == 1, "districts must not receive a fabricated radius")
+
+allow_operation = false
+assert(snapshot().error == "rate_limited")
+allow_operation = true
+Config.CityWarn.Enabled = false
+events["sky_phone:configurator:serverUpdated"]()
+assert(#snapshot().data.alerts == 0, "disabling CityWarn must return an empty authoritative snapshot")
+Config.CityWarn.Enabled = true
+events["sky_phone:configurator:serverUpdated"]()
+assert(#snapshot().data.alerts == 2)
+now = now + 61000
+assert(#snapshot().data.alerts == 0, "expiry must work without opening bootstrap or mutating DB status")
+
+publish()
+during_query = function() events["sky_phone:configurator:serverUpdated"]() end
+assert(snapshot().error == "revision_conflict", "an invalidated in-flight query must not populate the cache")
+assert(#snapshot().data.alerts == 1, "the next snapshot must recover after a racing change")
+
+print("CityWarn server lifecycle tests passed")


### PR DESCRIPTION
## Summary

CityWarn currently draws warning areas only inside the phone app. This adds GTA map/minimap blips for active warnings with coordinates, including a translucent area for radius warnings. Publishing and updates synchronize the blips; resolution, expiration, disabling CityWarn, and resource stop remove them.

Related issue: none; requested feature.

## Root cause and approach

The existing CityWarn client event only forwards data to NUI. A separate client now owns the native blip handles and fetches a small, authoritative snapshot independently of the phone session. The existing app map and notification handler continue to operate.

Snapshots load on join/resource start, reconcile every 30 seconds, retry after 5 seconds on failure, and refresh after warning events. In-flight snapshots are discarded when a newer event or configuration change arrives. Expiration uses database-derived remaining time and a separate client timer so a blocked callback cannot leave expired blips behind.

## Changes

- Create and update named point blips and severity-coloured radius areas without duplicate handles; clean up partial native failures and retry.
- Add a rate-limited, read-only `sky_phone:citywarn:blips` callback with a short shared cache. Return all located active warnings independently of the app page size, without warning bodies or author data.
- Invalidate cached snapshots on publish, update, resolve, and configurator changes. Ignore local change events, remove resolved blips immediately, and reject stale replies after shutdown or disabling CityWarn.
- Add Lua client/server lifecycle tests to the existing `Repository policy` CI job and document runtime behavior.

## Compatibility and migrations

No configuration, locale, SQL, framework, or export migration. The client reuses the localized CityWarn name and existing warning titles; all native coordinates are separate floats for experimental OAL.

Public GTA blips appear for all players regardless of phone ownership/open state or personal in-app filters. City-wide alerts and districts without coordinates continue to appear in the phone app without a fabricated GTA location. Existing publishing permissions and phone-session checks remain in place.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [ ] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes. Not applicable: no frontend source changes; targeted CityWarn tests passed.
- [ ] I ran a production frontend build for frontend changes. Not applicable: no frontend source changes; CI builds the test resource.
- [x] I tested affected Lua/native behavior with experimental OAL enabled, or marked the live runtime test as pending below.
- [x] I verified every changed NUI callback responds on every reachable path. No NUI callbacks changed.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
Lua 5.4 via lupa.lua54.LuaRuntime, dofile('tests/client_citywarn.lua'): PASS
Lua 5.4 via lupa.lua54.LuaRuntime, dofile('tests/server_citywarn.lua'): PASS
Lua 5.4 loadfile syntax check across sky_phone/ and tests/: PASS, 194 files
corepack pnpm@10.33.0 install --frozen-lockfile: PASS
corepack pnpm@10.33.0 exec vitest run src/stores/citywarn.test.ts src/views/apps/CityWarnApp.contract.test.ts: PASS, 8 tests
node .github/scripts/validate-repository.mjs: PASS
Repository Prettier check: PASS after normalizing Windows checkout line endings to the committed LF format
git diff --cached --check: PASS
actionlint: unavailable locally
```

The client suite covers startup recovery, duplicate and delayed events, position/radius/name/colour updates, district conversion, missed events, timeout-independent expiry, stale replies, disable/re-enable, partial native failures, missing handles, resource stop, invalid payloads, UTF-8 labels, and timer wraparound. Server tests exercise publish/update/resolve cache invalidation, public reads with protected writes, paging independence, cache ageing, rate limiting, expiry, configurator changes, and a query invalidated while in flight.

## Runtime evidence

Live FiveM testing after a resource restart with experimental OAL is **pending**. Local Lua tests use native and database stubs and do not prove the final GTA rendering. Test on two clients: publish/update/resolve a radius warning with both phones closed, join with an active warning, let one expire, and restart/disable the resource. Confirm point/radius placement, colours, names, cleanup, and the existing in-app map.

## Security and architecture

- [x] Consequential actions remain server-authoritative and validate identity, permissions, ownership, limits, and payloads.
- [x] This change introduces no dependency, event, export, global, config, persistence, or fallback connection to another `sky_*` resource.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

The blip callback intentionally exposes public map data without requiring an open phone. It accepts no client-selected warning data and performs no writes. Callback failures retain existing warnings only until their local expiry; a successful snapshot removes warnings no longer active.

Native signatures were checked against the Cfx sources for [AddBlipForCoord](https://github.com/citizenfx/natives/blob/master/HUD/AddBlipForCoord.md), [AddBlipForRadius](https://github.com/citizenfx/natives/blob/master/HUD/AddBlipForRadius.md), [SetBlipCoords](https://github.com/citizenfx/natives/blob/master/HUD/SetBlipCoords.md), and the associated display/name/removal natives.
