### PR TITLE
FIX - sync company profile fields from Phone Configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,13 @@ Set each definition's `CoverUrl` to an HTTPS image URL in the configuration or P
 admin-managed; job members cannot change them through Companies. Previously uploaded job
 logos and covers are no longer used automatically.
 
+Changes to `Description`, `District`, `LocationLabel`, and `Address` in the Phone Configurator
+also update existing company profiles. Each profile stores the last applied configuration so
+manager edits survive unrelated panel saves and resource restarts; changing a field in the panel
+overrides that field only. On the first restart after this update, the automatic schema migration
+adds `config_profile` and replaces remaining stock profile texts with the configured values.
+Existing custom texts are preserved during this initial reconciliation.
+
 Opening hours use 24-hour `HH:MM` input. `ServiceLine.CanMessage` enables company SMS and defaults
 to `true` for new companies and the shipped service lines. On the first restart after this update,
 the Phone Configurator enables SMS once for the stored `ambulance`, `fire`, `mechanic`, and `taxi`

--- a/sky_phone/source/server/companies.lua
+++ b/sky_phone/source/server/companies.lua
@@ -410,6 +410,71 @@ function SkyPhoneCompanies.ValidateConfiguration(configuration)
     return true
 end
 
+local function profile_configuration(definition)
+    return {
+        description = definition.Description or "",
+        district = definition.District or "",
+        location_label = definition.LocationLabel or definition.Address or "",
+        address = definition.Address or "",
+    }
+end
+
+local function sync_profile_configuration(company_id, definition)
+    local configured = profile_configuration(definition)
+    local defaults = ConfigDefaults.Companies.Definitions[company_id]
+    local legacy = defaults and profile_configuration(defaults) or {}
+    for _ = 1, 3 do
+        local rows = Bridge.Database.Query([[
+            SELECT `description`, `district`, `location_label`, `address`, `config_profile`, `revision`
+            FROM `sky_phone_company_profiles` WHERE `company_id` = ? LIMIT 1
+        ]], { company_id })
+        local row = rows[1]
+        if not row then
+            error(("[sky_phone] Missing company profile '%s' during configuration sync."):format(company_id))
+        end
+        local previous
+        if row.config_profile ~= nil then
+            local decoded, value = pcall(json.decode, row.config_profile)
+            if not decoded or type(value) ~= "table" then
+                error(("[sky_phone] Invalid configuration snapshot for company '%s'."):format(company_id))
+            end
+            previous = value
+        end
+        local set_parts, parameters = {}, {}
+        local configuration_changed = previous == nil
+        for _, field in ipairs({ "description", "district", "location_label", "address" }) do
+            if not previous or previous[field] ~= configured[field] then
+                configuration_changed = true
+                -- On upgrade, only replace recognizable stock values. Once a
+                -- snapshot exists, an explicit admin change wins for that field.
+                if (previous or row[field] == legacy[field]) and row[field] ~= configured[field] then
+                    set_parts[#set_parts + 1] = ("`%s` = ?"):format(field)
+                    parameters[#parameters + 1] = configured[field]
+                end
+            end
+        end
+        if not configuration_changed then
+            return
+        end
+        local profile_changed = #set_parts > 0
+        set_parts[#set_parts + 1] = "`config_profile` = ?"
+        parameters[#parameters + 1] = json.encode(configured)
+        set_parts[#set_parts + 1] = "`revision` = `revision` + 1"
+        set_parts[#set_parts + 1] = profile_changed and "`updated_at` = CURRENT_TIMESTAMP"
+            or "`updated_at` = `updated_at`"
+        parameters[#parameters + 1] = company_id
+        parameters[#parameters + 1] = tonumber(row.revision)
+        local result = Bridge.Database.Query(([[
+            UPDATE `sky_phone_company_profiles` SET %s WHERE `company_id` = ? AND `revision` = ?
+        ]]):format(table.concat(set_parts, ", ")), parameters)
+        local affected = type(result) == "table" and tonumber(result.affectedRows) or tonumber(result)
+        if affected == 1 then
+            return
+        end
+    end
+    error(("[sky_phone] Could not synchronize configuration for company '%s'."):format(company_id))
+end
+
 local function seed_companies()
     if #definition_ids > 0 then
         local placeholders = {}
@@ -467,6 +532,7 @@ local function seed_companies()
                 definition.AcceptsRequests and 1 or 0,
             })
         end
+        sync_profile_configuration(company_id, definition)
         for index, service in ipairs(definition.Services or {}) do
             Bridge.Database.Query([[
                 INSERT IGNORE INTO `sky_phone_company_services`
@@ -982,10 +1048,6 @@ local function refresh_runtime_configuration()
 end
 
 refresh_runtime_configuration()
-
-AddEventHandler("sky_phone:configurator:serverUpdated", function()
-    refresh_runtime_configuration()
-end)
 
 cleanup_retained_data()
 
@@ -1636,6 +1698,13 @@ local function emit_public_change(company_id)
         })
     end
 end
+
+AddEventHandler("sky_phone:configurator:serverUpdated", function()
+    refresh_runtime_configuration()
+    for _, company_id in ipairs(definition_ids) do
+        emit_public_change(company_id)
+    end
+end)
 
 local function emit_request_change(row, customer, company, excluded_source)
     local payload = {

--- a/sky_phone/source/server/db_migrate.lua
+++ b/sky_phone/source/server/db_migrate.lua
@@ -2606,6 +2606,7 @@ local schema = {
         name = "sky_phone_company_profiles",
         columns = {
             { name = "company_id", type = "VARCHAR(64) NOT NULL", characterSet = "ascii", collation = "ascii_bin" },
+            { name = "config_profile", type = "LONGTEXT NULL" },
             { name = "description", type = "VARCHAR(1000) NOT NULL DEFAULT ''" },
             { name = "district", type = "VARCHAR(80) NOT NULL DEFAULT ''" },
             { name = "location_label", type = "VARCHAR(80) NOT NULL DEFAULT ''" },

--- a/sky_phone/sql/install.sql
+++ b/sky_phone/sql/install.sql
@@ -1189,6 +1189,7 @@ CREATE TABLE IF NOT EXISTS `sky_phone_crewlink_pings` (
 
 CREATE TABLE IF NOT EXISTS `sky_phone_company_profiles` (
     `company_id` VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    `config_profile` LONGTEXT NULL,
     `description` VARCHAR(1000) NOT NULL DEFAULT '',
     `district` VARCHAR(80) NOT NULL DEFAULT '',
     `location_label` VARCHAR(80) NOT NULL DEFAULT '',

--- a/tests/companies_profile_config_sync.lua
+++ b/tests/companies_profile_config_sync.lua
@@ -1,0 +1,222 @@
+-- Run from the repository root with Lua 5.4. Exercise the full Companies module,
+-- including startup, Configurator refresh, SQL persistence and the public callback.
+local function copy(value)
+    if type(value) ~= "table" then return value end
+    local result = {}
+    for key, child in pairs(value) do result[key] = copy(child) end
+    return result
+end
+
+local function new_server(database, configuration)
+    database = database or { profiles = {}, services = {}, payloads = {}, writes = 0 }
+    local callbacks, handlers, events = {}, {}, {}
+    local env = setmetatable({
+        IsDuplicityVersion = function() return true end,
+        vector3 = function(x, y, z) return { x = x, y = y, z = z } end,
+        vector4 = function(x, y, z, w) return { x = x, y = y, z = z, w = w } end,
+        CreateThread = function() end,
+        AddEventHandler = function(name, callback) handlers[name] = callback end,
+        TriggerClientEvent = function(name, target, payload)
+            events[#events + 1] = { name = name, target = target, payload = copy(payload) }
+        end,
+    }, { __index = _G })
+    assert(loadfile("sky_phone/source/shared/config_default.lua", "t", env))()
+    env.Config = copy(configuration or env.ConfigDefaults)
+    env.json = {
+        encode = function(value)
+            local key = tostring(#database.payloads + 1)
+            database.payloads[tonumber(key)] = copy(value)
+            return key
+        end,
+        decode = function(key) return copy(assert(database.payloads[tonumber(key)])) end,
+    }
+    env.SkyPhone = {
+        AllowOperation = function() return true end,
+        RequireSession = function() return { imei = "test-device" } end,
+    }
+    env.Bridge = {
+        Debug = function() end,
+        Framework = {
+            GetPlayers = function() return { 1, 2 } end,
+            GetJob = function(player)
+                return { name = player == 1 and "police" or "unemployed", grade = 4 }
+            end,
+        },
+        Callbacks = { Register = function(name, callback) callbacks[name] = callback end },
+        Database = {
+            AfterMigration = function(_, callback) callback() end,
+            Transaction = function() return true end,
+            Query = function(sql, params)
+                if sql:find("INSERT IGNORE INTO `sky_phone_company_profiles`", 1, true) then
+                    if not database.profiles[params[1]] then
+                        local row = { revision = 1, updated_at_unix = 100, availability_updated_at_unix = 50 }
+                        local columns = assert(sql:match("%((.-)%)%s*VALUES"))
+                        local index = 0
+                        for column in columns:gmatch("`([^`]+)`") do
+                            index = index + 1
+                            row[column] = params[index]
+                        end
+                        database.profiles[params[1]] = row
+                    end
+                    return 0
+                end
+                if sql:find("INSERT IGNORE INTO `sky_phone_company_services`", 1, true) then
+                    database.services[params[1]] = database.services[params[1]] or params[2]
+                    return 0
+                end
+                if sql:find("UPDATE `sky_phone_company_profiles` SET", 1, true) then
+                    local row = assert(database.profiles[params[#params - 1]])
+                    if database.conflict then
+                        database.conflict(row)
+                        database.conflict = nil
+                        return { affectedRows = 0 }
+                    end
+                    if database.fail_updates or row.revision ~= params[#params] then return 0 end
+                    local assignments = assert(sql:match("SET (.-) WHERE"))
+                    local index = 0
+                    for column in assignments:gmatch("`([^`]+)` = %?") do
+                        index = index + 1
+                        row[column] = params[index]
+                    end
+                    assert(index == #params - 2, "Every SQL placeholder must have a parameter")
+                    assert(assignments:find("`revision` = `revision` + 1", 1, true))
+                    row.revision = row.revision + 1
+                    if assignments:find("`updated_at` = CURRENT_TIMESTAMP", 1, true) then
+                        row.updated_at_unix = row.updated_at_unix + 1
+                    end
+                    database.writes = database.writes + 1
+                    return { affectedRows = 1 }
+                end
+                if sql:find("SELECT DISTINCT profile.", 1, true) then return {} end
+                if sql:find("FROM `sky_phone_company_profiles`", 1, true) then
+                    local row = database.profiles[params[1]]
+                    return row and { copy(row) } or {}
+                end
+                if sql:find("SELECT `company_id` FROM `sky_phone_company_services`", 1, true) then
+                    return { { company_id = database.services[params[1]] } }
+                end
+                if sql:find("FROM `sky_phone_migrations`", 1, true) then return { {} } end
+                if sql:find("FROM `sky_phone_devices`", 1, true) then return { { device_name = "Phone" } } end
+                for _, name in ipairs({ "sims", "company_services", "company_hours", "company_announcements" }) do
+                    if sql:find("FROM `sky_phone_" .. name .. "`", 1, true) then return {} end
+                end
+                error("Unexpected SQL: " .. sql)
+            end,
+        },
+    }
+    assert(loadfile("sky_phone/source/shared/sim_number.lua", "t", env))()
+    assert(loadfile("sky_phone/source/server/companies.lua", "t", env))()
+    local server = { env = env, database = database, events = events }
+    function server.refresh() handlers["sky_phone:configurator:serverUpdated"]() end
+    function server.company()
+        local result = callbacks["sky_phone:companies:get"](2, { companyId = "police" })
+        assert(result.success, result.error)
+        return result.data.company
+    end
+    return server
+end
+
+local server = new_server()
+local database = server.database
+local writes = database.writes
+local row = database.profiles.police
+local original_availability_time = row.availability_updated_at_unix
+local original_timestamp = row.updated_at_unix
+assert(original_timestamp == 100, "Initializing a snapshot must preserve profile timestamps")
+server.refresh()
+assert(database.writes == writes, "Unchanged configuration must not rewrite profiles")
+assert(row.updated_at_unix == original_timestamp)
+
+-- Reproduce the screenshot: an already seeded profile with all four panel values changed.
+local definition = server.env.Config.Companies.Definitions.police
+definition.Name = "Vespucci PD"
+definition.Description = "Polizei"
+definition.District = "Vespucci"
+definition.LocationLabel = "Vespucci Beach"
+definition.Address = "5943"
+local previous_revision = row.revision
+server.refresh()
+local company = server.company()
+assert(company.name == "Vespucci PD" and company.description == "Polizei")
+assert(company.location.district == "Vespucci" and company.location.label == "Vespucci Beach")
+assert(company.location.address == "5943")
+assert(row.revision == previous_revision + 1, "Panel edits must invalidate stale manager drafts")
+assert(row.availability_updated_at_unix == original_availability_time)
+local work_event, directory_event = false, false
+for _, event in ipairs(server.events) do
+    if event.name == "sky_phone:companies:changed" and event.payload.companyId == "police" then
+        work_event = work_event or event.target == 1 and event.payload.area == "work"
+        directory_event = directory_event or event.target == 2 and event.payload.area == "directory"
+    end
+end
+assert(work_event and directory_event, "Panel saves must refresh open public and manager views")
+
+-- Manager data stays in SQL until the admin changes that specific field again.
+row.description = "Manager description"
+row.address = "Manager address"
+row.availability = "busy"
+row.accepts_requests = 0
+row.revision = row.revision + 1
+writes = database.writes
+definition.LogoUrl = "https://example.com/new-logo.jpg"
+server.refresh()
+assert(database.writes == writes and row.description == "Manager description")
+server = new_server(database, server.env.Config)
+assert(database.writes == writes and server.company().location.address == "Manager address")
+definition = server.env.Config.Companies.Definitions.police
+definition.Description = "Neue Beschreibung"
+server.refresh()
+assert(row.description == "Neue Beschreibung" and row.address == "Manager address")
+assert(row.availability == "busy" and row.accepts_requests == 0)
+definition.Description = ""
+definition.District = ""
+definition.LocationLabel = ""
+definition.Address = ""
+server.refresh()
+company = server.company()
+assert(company.description == "" and company.location.district == "")
+assert(company.location.label == "" and company.location.address == "", "Blank panel values must clear old text")
+
+-- Config values changed while stopped must also be applied on the next start.
+definition.Description = "After restart"
+server = new_server(database, server.env.Config)
+assert(server.company().description == "After restart")
+
+-- Upgrade legacy stock profiles, preserving fields already customized by a manager.
+local legacy = new_server()
+local legacy_row = legacy.database.profiles.police
+legacy_row.config_profile = nil
+local updated_config = copy(legacy.env.Config)
+local updated = updated_config.Companies.Definitions.police
+updated.Description, updated.District = "Polizei", "Vespucci"
+updated.LocationLabel, updated.Address = "Vespucci Beach", "5943"
+legacy = new_server(legacy.database, updated_config)
+company = legacy.company()
+assert(company.description == "Polizei" and company.location.district == "Vespucci")
+assert(company.location.label == "Vespucci Beach" and company.location.address == "5943")
+assert(legacy_row.config_profile ~= nil)
+
+local custom = new_server()
+custom.database.profiles.police.config_profile = nil
+custom.database.profiles.police.address = "Legacy manager address"
+custom = new_server(custom.database, updated_config)
+assert(custom.company().description == "Polizei")
+assert(custom.company().location.address == "Legacy manager address")
+
+-- A concurrent manager write must be re-read, not silently overwritten or discarded.
+legacy.env.Config.Companies.Definitions.police.Description = "Admin update"
+legacy.database.conflict = function(profile)
+    profile.address = "Concurrent manager address"
+    profile.revision = profile.revision + 1
+end
+legacy.refresh()
+assert(legacy_row.description == "Admin update" and legacy_row.address == "Concurrent manager address")
+
+legacy.env.Config.Companies.Definitions.police.Description = "Must fail"
+legacy.database.fail_updates = true
+assert(not pcall(legacy.refresh), "Persistent SQL conflicts must fail visibly")
+legacy.database.fail_updates = false
+legacy_row.config_profile = "corrupt"
+assert(not pcall(legacy.refresh), "Corrupt snapshots must fail visibly")
+
+print("Companies profile configuration sync tests passed")

--- a/tests/phone_configurator.lua
+++ b/tests/phone_configurator.lua
@@ -223,3 +223,5 @@ test("stale revisions cannot overwrite saved settings", function()
 end)
 
 assert(failures == 0, ("%s phone configurator tests failed"):format(failures))
+
+dofile("tests/companies_profile_config_sync.lua")


### PR DESCRIPTION
## Summary

Editing `Address`, `Description`, `District`, or `LocationLabel` in the Phone Configurator now updates existing company profiles. For example, changing the police profile to Vespucci no longer leaves the old Mission Row address and description visible in Companies.

No linked GitHub issue.

## Root cause and approach

Company names and images used the current configuration, while these four text fields were read from SQL profiles initialized with `INSERT IGNORE`. Subsequent panel saves never updated those rows. Persist the last configured text values and synchronize only fields whose configuration changes, preserving manager edits across unrelated saves and restarts.

## Changes

- Synchronize the four profile fields during startup and Configurator refresh, including intentionally empty values.
- Reconcile recognizable stock text on existing installations while preserving custom text during the first sync.
- Advance profile revisions with optimistic concurrency checks and notify public and manager views after panel saves.
- Add regression coverage to the existing Phone Configurator test entry point and document the update behavior.

## Compatibility and migrations

The automatic runtime schema migration adds nullable `config_profile` to `sky_phone_company_profiles`; the clean-install SQL includes the same column. Deploy the updated resource and restart `sky_phone`. No manual SQL is required. Existing custom text is preserved during initial reconciliation; later explicit panel changes override only the changed field. Public callbacks and configuration defaults remain compatible.

## Validation

- [x] Ran the narrowest relevant automated tests.
- [x] Frontend typecheck, lint, and full test requirements: not applicable; no frontend source changes.
- [x] Production frontend build requirement: not applicable; no frontend source changes.
- [x] Affected behavior tested in FiveM by the user; the resource manifest retains experimental OAL.
- [x] NUI callback response review: no NUI callbacks changed.
- [x] Reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
node .github/scripts/validate-repository.mjs
  PASS
git diff --cached --check
  PASS
python -c "from lupa.lua54 import LuaRuntime; LuaRuntime().eval('dofile')('tests/phone_configurator.lua')"
  PASS, including the new Companies profile synchronization suite
Lua 5.4 via Python/Lupa: compile all resource and test Lua files
  PASS (197 files)
Lua 5.4 via Python/Lupa: tests/companies_profile.lua,
  tests/companies_call_availability_spec.lua, tests/server_phone_modules.lua
  PASS
cd frontend
pnpm exec vitest run src/companiesProfile.contract.test.ts src/stores/companies.test.ts src/companyConfiguratorCreation.contract.test.ts src/companiesServiceLineCalls.contract.test.ts src/companiesServiceLineMessages.contract.test.ts src/companiesEmergencyRequests.contract.test.ts
  PASS (43 tests across 6 files)
```

## Runtime evidence

The user confirmed that the in-game test of the fix was successful before requesting this PR. Automated tests additionally cover panel changes, resource restarts, legacy profiles, manager edits, empty values, concurrent writes, and invalid snapshots.

## Security and architecture

- [x] Consequential actions remain server-authoritative and retain existing authorization and validation.
- [x] No connection or dependency on another `sky_*` resource is introduced.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

On the initial upgrade, custom legacy text has no reliable configuration history and is therefore preserved. After the snapshot is initialized, explicitly changing a field in the panel takes precedence over that field's manager value.
