### PR TITLE
FIX - restore light-mode widget and call contrast

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1935,7 +1935,8 @@ onBeforeUnmount(() => {
                     'phone-app--light': !displayedDarkMode,
                     'phone-app--messages': route.params.appId === 'messages',
                     'phone-app--status-light':
-                      WHITE_STATUS_BAR_APP_IDS.has(activeAppId),
+                      WHITE_STATUS_BAR_APP_IDS.has(activeAppId) ||
+                      (activeAppId === 'phone' && calls.activeCall !== null),
                     'phone-app--status-dark':
                       DARK_STATUS_BAR_APP_IDS.has(activeAppId),
                     'phone-app--setup': setupRequired,

--- a/frontend/src/components/WidgetConfigSheet.vue
+++ b/frontend/src/components/WidgetConfigSheet.vue
@@ -284,11 +284,15 @@ watch(
 .widget-config-navbar :deep(.widget-config-nav-button.sky-button) {
   min-height: var(--sky-touch-target);
   padding: 0 var(--sky-space-4);
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: var(--sky-surface-variant);
+  border: 1px solid var(--sky-action-border);
+  background: var(--sky-action-surface);
   color: #fff;
   font-size: 15px;
   font-weight: 600;
+}
+
+.widget-config-navbar :deep(.widget-config-nav-button.sky-button:active) {
+  background: var(--sky-action-pressed);
 }
 
 .widget-config-scroll {

--- a/frontend/src/components/WidgetPickerSheet.vue
+++ b/frontend/src/components/WidgetPickerSheet.vue
@@ -393,11 +393,15 @@ watch(
 .widget-picker-navbar :deep(.widget-picker-nav-button.sky-button) {
   min-height: var(--sky-touch-target);
   padding: 0 var(--sky-space-4);
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: var(--sky-surface-variant);
+  border: 1px solid var(--sky-action-border);
+  background: var(--sky-action-surface);
   color: #fff;
   font-size: 15px;
   font-weight: 600;
+}
+
+.widget-picker-navbar :deep(.widget-picker-nav-button.sky-button:active) {
+  background: var(--sky-action-pressed);
 }
 
 .widget-picker-navbar :deep(.widget-picker-nav-button--icon.sky-button) {

--- a/frontend/src/ui/tokens.css
+++ b/frontend/src/ui/tokens.css
@@ -163,6 +163,11 @@
   --sky-surface-tint: #ffffff;
   --sky-surface-muted: #f7f7f8;
   --sky-surface-variant: #f4f4f4;
+  /* Solid action surfaces keep white labels readable in either theme. */
+  --sky-action-surface: #1c1c1d;
+  --sky-action-pressed: #323234;
+  --sky-action-muted: rgba(255, 255, 255, 0.65);
+  --sky-action-border: rgba(255, 255, 255, 0.22);
   --sky-message-received-background: #e5e5ea;
   --sky-message-meta: rgba(0, 0, 0, 0.45);
   --sky-messagebar-gradient-start: #efeff4;

--- a/frontend/src/views/SpringboardView.vue
+++ b/frontend/src/views/SpringboardView.vue
@@ -2135,19 +2135,25 @@ onBeforeUnmount(() => {
 
 .widget-action-sheet :deep(.sky-action-group) {
   border-radius: var(--sky-radius-card);
-  background: var(--sky-surface);
+  background: var(--sky-action-surface);
+  box-shadow: none;
 }
 
 .widget-action-sheet :deep(.sky-actions-label) {
-  color: var(--sky-muted);
+  color: var(--sky-action-muted);
   background: transparent;
   font-size: 14px;
   font-weight: 600;
 }
 
 .widget-action-sheet :deep(.sky-action-button) {
+  border-color: var(--sky-action-border);
   color: #fff;
   font-size: 17px;
+}
+
+.widget-action-sheet :deep(.sky-action-button:active) {
+  background: var(--sky-action-pressed);
 }
 
 .widget-action-sheet :deep(.widget-action-button) {

--- a/frontend/src/views/apps/PhoneApp.vue
+++ b/frontend/src/views/apps/PhoneApp.vue
@@ -8,6 +8,7 @@ import {
   SkyList,
   SkyField,
   SkyAppPage,
+  SkyProvider,
   SkySegmented,
   SkySegmentedButton,
   SkySheet,
@@ -744,9 +745,11 @@ onBeforeUnmount(() => {
     }"
   >
     <template v-if="calls.activeCall">
-      <section
+      <SkyProvider
         class="phone-active-call"
         :class="{ 'phone-active-call--more': callMoreOpened }"
+        component="section"
+        dark
       >
         <header class="phone-active-call__identity">
           <div class="phone-active-call__status">
@@ -966,7 +969,7 @@ onBeforeUnmount(() => {
             </sky-button>
           </div>
         </Transition>
-      </section>
+      </SkyProvider>
     </template>
 
     <template v-else>
@@ -1924,10 +1927,10 @@ onBeforeUnmount(() => {
   left: 50%;
   width: 80px;
   height: 80px;
-  border: 1px solid var(--sky-hairline);
+  border: 1px solid var(--sky-action-border);
   border-radius: 50%;
-  background: var(--sky-glass);
-  box-shadow: var(--sky-shadow-glass);
+  background: var(--sky-action-surface);
+  box-shadow: none;
   content: '';
   transform: translateX(-50%);
   transition:
@@ -1980,7 +1983,9 @@ onBeforeUnmount(() => {
 }
 
 .phone-call-action.is-active::before {
-  background: rgba(255, 255, 255, 0.24);
+  border-color: var(--sky-app-accent-tint);
+  background: var(--sky-app-accent-shade);
+  box-shadow: inset 0 0 0 2px var(--sky-app-accent-tint);
 }
 
 .phone-call-action.is-disabled {
@@ -3740,10 +3745,7 @@ onBeforeUnmount(() => {
   .phone-call-action:not(:disabled):not(.phone-call-action--end):not(
       .phone-call-action--answer
     ):hover::before {
-    background: rgba(255, 255, 255, 0.22);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.12),
-      0 4px 12px rgba(0, 0, 0, 0.22);
+    filter: brightness(1.15);
     transform: translateX(-50%) translateY(-1px) scale(1.012);
   }
 


### PR DESCRIPTION
## Summary

Light mode made widget actions and editor buttons unreadable, and pale call buttons obscured white icons and their selected state. These controls now retain readable white foregrounds, and active speaker/mute controls have a distinct fill and border.

## Root cause and approach

The affected controls combined fixed white foregrounds with surfaces inherited from the light theme. The call screen also has a permanently dark background, but its menus and status bar inherited the surrounding phone theme. Shared solid action tokens fix the widget controls, while a local dark SkyProvider keeps the complete call surface consistent.

## Changes

- Apply contrasting surfaces to the widget action sheet and the configuration/picker header buttons, including pressed states.
- Preserve selected call-button colors and borders on hover.
- Keep call submenus, keypad controls, and the status bar readable while returning to the normal theme after the call.

## Compatibility and migrations

None. No configuration, locale, SQL, callback, public API, dependency, or integration changes.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [x] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes.
- [x] I ran a production frontend build for frontend changes.
- [x] I marked the live runtime test as pending below; no Lua/native behavior changed.
- [x] I verified changed NUI callback coverage; no callbacks changed.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
Focused widget/call tests: 28 passed
Focused status/theme/lifecycle tests: 17 passed
pnpm test: 237 files, 1422 tests passed; 71 browser mock endpoints/actions verified
pnpm lint: passed
pnpm exec prettier --check <six changed frontend files>: passed
build_frontend.bat: typecheck, production build, and local resource copies passed
node .github/scripts/validate-repository.mjs: passed
Git diff checks: passed
```

## Runtime evidence

Inspected browser screenshots in light and dark modes using Edge 153 and the local mock backend. Checked widget menus, configuration and picker buttons, active/inactive speaker and mute controls, hover preservation, both toggle roundtrips, call submenus/keypad, and status-bar restoration after ending a call. Measured foreground/background contrast for the affected enabled controls and verified the widget header buttons retain 44px targets. No browser page errors occurred.

The generated NUI retains the configured Chrome 103 target. Live FiveM/CEF validation remains pending; browser and local build checks are not in-game proof.

## Security and architecture

- [x] Consequential actions remain server-authoritative.
- [x] No connection to another Sky resource is introduced.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

FaceTime remains disabled as before. The unrelated functional support reports are outside this styling fix. The Windows test run used LF normalization for an existing Radio Configurator text assertion; those resource files have no content changes in this PR.