### PR TITLE
ADD - support MSK Garage and clean up valet drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,18 @@ The migration command is server-console only.
 
 Select the provider under `Config.Garage.System`. Vehicle images use the configured CDN template with an icon fallback when no image is available.
 
+For MSK Garage, select `msk` (or use `auto`) and start `msk_garage` before `sky_phone`.
+With the Phone Configurator enabled, set `Garage.System` to `msk` in `/phonepanel` instead.
+Automatic detection checks `jg-advancedgarages` before `msk_garage`; select `msk` explicitly if both run.
+The adapter uses MSK's standard framework vehicle schema: ESX `owned_vehicles` / `stored`,
+or QBCore and Qbox `player_vehicles` / `state` (MSK 5.6+). It reads the garage ID,
+custom vehicle name, properties and fuel, and changes only the parked flag for valet orders.
+MSK treats unparked vehicles as impound candidates; the phone shows them as out and only
+delivers parked, personally owned vehicles. Cancelled or failed deliveries restore the parked flag.
+With `msk_fuel`, valet preserves liters; the fuel percentage is available when that resource
+configures a tank capacity for the model. Otherwise the percentage is shown as unavailable.
+See the [MSK database contract](https://docu.msk-scripts.de/docs/msk_garage/database/).
+
 ### Housing
 
 Select `rtx`, `quasar`, `tgiann`, `vms`, `rx`, `nolag`, `sn`, `esx_property`, or `qbx_properties` under `Config.Housing.System`. Automatic mode uses `Config.Housing.AutoPriority` and keeps the existing `esx_property` and `qbx_properties` defaults ahead of newly supported providers. Select a provider explicitly when multiple housing resources are running. Each bridge exposes only the capabilities supported by the documented provider API. The TGIANN bridge expects `tgiann-core` to start before `tgiann-house`, lists server-authorized owner properties, and supports entrance waypoints; TGIANN does not publish stable external contracts for keyholders, lock controls, CCTV, or live garage status.

--- a/frontend/src/utils/adminConfiguratorDescription.test.ts
+++ b/frontend/src/utils/adminConfiguratorDescription.test.ts
@@ -10,6 +10,9 @@ import {
 
 describe('admin configurator descriptions', () => {
   it('selects specific descriptions before generic value descriptions', () => {
+    expect(configuratorDescriptionKey('Garage.System', 'msk')).toBe(
+      'garageSystem',
+    )
     expect(configuratorDescriptionKey('Bridge.CallbackTimeout', 15000)).toBe(
       'milliseconds',
     )

--- a/frontend/src/utils/adminConfiguratorDescription.ts
+++ b/frontend/src/utils/adminConfiguratorDescription.ts
@@ -69,6 +69,7 @@ export function configuratorDescriptionKey(
   value: unknown,
   structure?: AdminConfiguratorStructure,
 ): string {
+  if (path === 'Garage.System') return 'garageSystem'
   if (/^Companies\.Definitions\.[^.]+\.Name$/.test(path)) return 'companyName'
   if (/^Companies\.Definitions\.[^.]+\.LogoUrl$/.test(path))
     return 'companyLogo'

--- a/sky_phone/README.md
+++ b/sky_phone/README.md
@@ -536,6 +536,18 @@ The migration command is server-console only.
 
 Select the provider under `Config.Garage.System`. Vehicle images use the configured CDN template with an icon fallback when no image is available.
 
+For MSK Garage, select `msk` (or use `auto`) and start `msk_garage` before `sky_phone`.
+With the Phone Configurator enabled, set `Garage.System` to `msk` in `/phonepanel` instead.
+Automatic detection checks `jg-advancedgarages` before `msk_garage`; select `msk` explicitly if both run.
+The adapter uses MSK's standard framework vehicle schema: ESX `owned_vehicles` / `stored`,
+or QBCore and Qbox `player_vehicles` / `state` (MSK 5.6+). It reads the garage ID,
+custom vehicle name, properties and fuel, and changes only the parked flag for valet orders.
+MSK treats unparked vehicles as impound candidates; the phone shows them as out and only
+delivers parked, personally owned vehicles. Cancelled or failed deliveries restore the parked flag.
+With `msk_fuel`, valet preserves liters; the fuel percentage is available when that resource
+configures a tank capacity for the model. Otherwise the percentage is shown as unavailable.
+See the [MSK database contract](https://docu.msk-scripts.de/docs/msk_garage/database/).
+
 ### Housing
 
 Select `rtx`, `quasar`, `vms`, `rx`, `nolag`, `sn`, `esx_property`, or `qbx_properties` under `Config.Housing.System`. Automatic mode uses `Config.Housing.AutoPriority` and keeps the existing `esx_property` and `qbx_properties` defaults ahead of newly supported providers. Select a provider explicitly when multiple housing resources are running. Each bridge exposes only the capabilities supported by the documented provider API.

--- a/sky_phone/config/config.lua
+++ b/sky_phone/config/config.lua
@@ -440,7 +440,7 @@ Config.Billing = {
 }
 
 Config.Garage = {
-    System = "auto", -- auto, custom, esx, qb, qbox, ak47, bp, cd, codem, ds-servercreator, hex, jg, my, okok, op, quasar, rx, vms, ws, zyke_garages
+    System = "auto", -- auto, custom, esx, qb, qbox, ak47, bp, cd, codem, ds-servercreator, hex, jg, msk, my, okok, op, quasar, rx, vms, ws, zyke_garages
     MaximumVehicles = 250,
     RequestsPerMinute = 30,
     VehicleImages = {

--- a/sky_phone/config/locales/de.lua
+++ b/sky_phone/config/locales/de.lua
@@ -2141,6 +2141,7 @@ Locales["de"] = {
     },
 }
 
+Locales["de"].Nui.AdminPanel.configurator.descriptions.garageSystem = "Garagensystem: msk für msk_garage verwenden. Auto erkennt zuerst jg-advancedgarages, dann msk_garage und danach die Framework-Garage."
 Locales["de"].Nui.AdminPanel.configurator.table.addJob = "Job hinzufügen"
 Locales["de"].Nui.AdminPanel.configurator.table.jobPlaceholder = "Jobname"
 Locales["de"].Nui.AdminPanel.configurator.table.subtabs = {

--- a/sky_phone/config/locales/en.lua
+++ b/sky_phone/config/locales/en.lua
@@ -2141,6 +2141,7 @@ Locales["en"] = {
     },
 }
 
+Locales["en"].Nui.AdminPanel.configurator.descriptions.garageSystem = "Garage provider: use msk for msk_garage. Auto detects jg-advancedgarages first, then msk_garage, then the framework garage."
 Locales["en"].Nui.AdminPanel.configurator.table.addJob = "Add job"
 Locales["en"].Nui.AdminPanel.configurator.table.jobPlaceholder = "Job name"
 Locales["en"].Nui.AdminPanel.configurator.table.subtabs = {

--- a/sky_phone/config/locales/es.lua
+++ b/sky_phone/config/locales/es.lua
@@ -2141,6 +2141,7 @@ Locales["es"] = {
     },
 }
 
+Locales["es"].Nui.AdminPanel.configurator.descriptions.garageSystem = "Proveedor de garajes: usa msk para msk_garage. Auto detecta primero jg-advancedgarages, después msk_garage y luego el garaje del framework."
 Locales["es"].Nui.AdminPanel.configurator.table.addJob = "Añadir trabajo"
 Locales["es"].Nui.AdminPanel.configurator.table.jobPlaceholder = "Nombre del trabajo"
 Locales["es"].Nui.AdminPanel.configurator.table.subtabs = {

--- a/sky_phone/source/client/garage.lua
+++ b/sky_phone/source/client/garage.lua
@@ -80,12 +80,20 @@ RegisterNUICallback("garage:vehicles", function(data, cb)
         cb(type(result) == "table" and result or { success = false, error = "request_failed" })
         return
     end
+    local msk_fuel_config
     for _, vehicle in ipairs(result.data.vehicles or {}) do
         local model_hash = tonumber(vehicle.model)
         if not model_hash and type(vehicle.model) == "string" and vehicle.model ~= "" then
             model_hash = joaat(vehicle.model)
         end
         if model_hash then
+            if vehicle.mskFuel ~= nil and GetResourceState("msk_fuel") == "started" then
+                msk_fuel_config = msk_fuel_config or exports.msk_fuel:Config()
+                local capacity = tonumber((msk_fuel_config.PetrolTankVolume or {})[model_hash])
+                if capacity and capacity > 0 then
+                    vehicle.fuel = math.max(0, math.min(100, math.floor(vehicle.mskFuel / capacity * 100 + 0.5)))
+                end
+            end
             local display_name = GetDisplayNameFromVehicleModel(model_hash)
             local label = display_name and GetLabelText(display_name) or nil
             if label and label ~= "NULL" and label ~= "CARNOTFOUND" then
@@ -95,6 +103,7 @@ RegisterNUICallback("garage:vehicles", function(data, cb)
             end
             vehicle.kind = vehicle_kind(model_hash, vehicle.kind)
         end
+        vehicle.mskFuel = nil
     end
     cb(result)
 end)
@@ -198,10 +207,21 @@ local function apply_vehicle_properties(vehicle, properties, fallback)
         end
     end
     local fuel = tonumber(properties.fuelLevel or properties.fuel or fallback.fuel)
+    if fallback.garageSystem == "msk" then
+        fuel = tonumber(fallback.fuel) or fuel
+    end
     local engine = tonumber(properties.engineHealth or properties.engine or fallback.engine and fallback.engine * 10)
     local body = tonumber(properties.bodyHealth or properties.body or fallback.body and fallback.body * 10)
     if fuel then
-        SetVehicleFuelLevel(vehicle, math.max(0.0, math.min(100.0, fuel)))
+        if fallback.garageSystem == "msk" and GetResourceState("msk_fuel") == "started" then
+            exports.msk_fuel:SetVehicleFuel(vehicle, math.max(0.0, fuel))
+        else
+            fuel = math.max(0.0, math.min(100.0, fuel))
+            SetVehicleFuelLevel(vehicle, fuel)
+            if fallback.garageSystem == "msk" then
+                Entity(vehicle).state:set("fuel", fuel, true)
+            end
+        end
     end
     if engine then
         SetVehicleEngineHealth(vehicle, math.max(-4000.0, math.min(1000.0, engine)))

--- a/sky_phone/source/client/garage.lua
+++ b/sky_phone/source/client/garage.lua
@@ -263,9 +263,11 @@ local function delete_valet_entities()
     if current_valet.driver and DoesEntityExist(current_valet.driver) then
         DeleteEntity(current_valet.driver)
     end
+    current_valet.driver = nil
     if current_valet.vehicle and DoesEntityExist(current_valet.vehicle) then
         DeleteEntity(current_valet.vehicle)
     end
+    current_valet.vehicle = nil
 end
 
 local function fail_valet(error_code, server_cancel)
@@ -431,6 +433,7 @@ local function run_valet_delivery(order)
         return
     end
 
+    local valet = current_valet
     current_valet.status = "arriving"
     current_valet.can_cancel = false
     current_valet.distance = 0
@@ -438,28 +441,66 @@ local function run_valet_delivery(order)
     send_valet_state()
     TaskVehicleTempAction(driver, vehicle, 27, 1800)
     Wait(1800)
+    if current_valet ~= valet or valet.cancelled then
+        return
+    end
+    if not DoesEntityExist(vehicle) or not DoesEntityExist(driver) then
+        fail_valet("valet_interrupted", true)
+        return
+    end
     SetVehicleEngineOn(vehicle, false, true, true)
     SetVehicleDoorsLocked(vehicle, 1)
+    -- End the driving task before handing the vehicle over to its owner.
+    SetPedKeepTask(driver, false)
+    ClearPedTasks(driver)
     TaskLeaveVehicle(driver, vehicle, 0)
 
     local leave_timeout = GetGameTimer() + 5000
-    while IsPedInVehicle(driver, vehicle, false) and GetGameTimer() < leave_timeout do
+    while current_valet == valet and not valet.cancelled
+        and DoesEntityExist(driver) and DoesEntityExist(vehicle) and GetGameTimer() < leave_timeout
+    do
+        local leave_status = GetScriptTaskStatus(driver, joaat("SCRIPT_TASK_LEAVE_VEHICLE"))
+        if not IsPedInVehicle(driver, vehicle, false) and leave_status ~= 0 and leave_status ~= 1 then
+            break
+        end
         Wait(100)
     end
-    local driver_target = GetOffsetFromEntityInWorldCoords(vehicle, 4.0, 8.0, 0.0)
-    TaskGoStraightToCoord(
-        driver,
-        driver_target.x,
-        driver_target.y,
-        driver_target.z,
-        1.0,
-        10000,
-        GetEntityHeading(driver),
-        0.5
-    )
-    SetPedKeepTask(driver, true)
-    SetEntityAsNoLongerNeeded(driver)
-    current_valet.driver = nil
+    if current_valet ~= valet or valet.cancelled then
+        return
+    end
+    if not DoesEntityExist(vehicle) or not DoesEntityExist(driver) then
+        fail_valet("valet_interrupted", true)
+        return
+    end
+    if IsPedInVehicle(driver, vehicle, false) then
+        -- A blocked exit must not leave the delivered vehicle occupied.
+        DeleteEntity(driver)
+        valet.driver = nil
+    else
+        local driver_target = GetOffsetFromEntityInWorldCoords(vehicle, 4.0, 8.0, 0.0)
+        ClearPedTasks(driver)
+        TaskFollowNavMeshToCoord(
+            driver,
+            driver_target.x,
+            driver_target.y,
+            driver_target.z,
+            1.0,
+            10000,
+            0.5,
+            0,
+            GetEntityHeading(driver)
+        )
+        SetPedKeepTask(driver, true)
+        -- Keep ownership until explicit cleanup so ambient AI cannot reclaim the car.
+        SetTimeout(10000, function()
+            if valet.driver == driver then
+                if DoesEntityExist(driver) then
+                    DeleteEntity(driver)
+                end
+                valet.driver = nil
+            end
+        end)
+    end
 
     local completion = Bridge.Callbacks.Trigger(
         "sky_phone:garage:valet-complete",
@@ -468,6 +509,9 @@ local function run_valet_delivery(order)
             networkId = NetworkGetNetworkIdFromEntity(vehicle),
         }
     )
+    if current_valet ~= valet or valet.cancelled then
+        return
+    end
     if not completion or not completion.success then
         fail_valet("valet_completion_failed", false)
         return

--- a/sky_phone/source/server/garage.lua
+++ b/sky_phone/source/server/garage.lua
@@ -15,6 +15,7 @@ local supported_systems = {
     ["ds-servercreator"] = true,
     hex = true,
     jg = true,
+    msk = true,
     my = true,
     okok = true,
     op = true,
@@ -66,6 +67,14 @@ local function normalized_health(value, maximum)
 end
 
 local function vehicle_status(row, location, garage_system)
+    if garage_system == "msk" then
+        -- MSK owns only the framework's parked flag. Other garage columns may be stale.
+        local stored = row.state
+        if Bridge.Framework.GetName() == "esx" then
+            stored = row.stored
+        end
+        return truthy_database_value(stored) and "garaged" or "out"
+    end
     local state = tonumber(row.state)
     local location_key = string.lower(tostring(location or ""))
     if truthy_database_value(row.impound)
@@ -91,22 +100,28 @@ end
 
 local function vehicle_kind(value)
     local kind = string.lower(tostring(value or ""))
-    if kind == "boat" then
+    if kind == "boat" or kind == "submarine" or kind == "submarinecar" then
         return "boat"
     end
-    if kind == "plane" or kind == "air" or kind == "airplane" then
+    if kind == "plane" or kind == "air" or kind == "airplane" or kind == "aircraft" then
         return "plane"
     end
     if kind == "heli" or kind == "helicopter" then
         return "helicopter"
     end
-    if kind == "bike" or kind == "bicycle" or kind == "motorcycle" then
+    if kind == "bike" or kind == "bicycle" or kind == "motorcycle" or kind == "motorbike" then
         return "bike"
     end
     return "car"
 end
 
-local function vehicle_properties(row)
+local function vehicle_properties(row, garage_system)
+    if garage_system == "msk" then
+        if Bridge.Framework.GetName() == "esx" then
+            return decode_object(row.vehicle)
+        end
+        return decode_object(row.mods)
+    end
     local properties = decode_object(first_value(row.mods, row.vehicle_data, row.properties))
     local vehicle_object = decode_object(row.vehicle)
     if next(vehicle_object) ~= nil then
@@ -144,7 +159,7 @@ local function vehicle_image_url(model)
 end
 
 local function vehicle_dto(row, garage_system)
-    local mods = vehicle_properties(row)
+    local mods = vehicle_properties(row, garage_system)
     local vehicle_value = row.vehicle
 
     local model = first_value(row.model, row.hash, mods.model, mods.hash)
@@ -153,26 +168,52 @@ local function vehicle_dto(row, garage_system)
     elseif type(vehicle_value) == "number" then
         model = first_value(model, vehicle_value)
     end
+    if garage_system == "msk" then
+        if Bridge.Framework.GetName() == "esx" then
+            model = first_value(mods.model, mods.hash)
+        else
+            model = first_value(row.hash, mods.model, mods.hash, row.vehicle)
+        end
+    end
     local numeric_model = tonumber(model)
     if numeric_model then
         model = numeric_model
     end
 
     local location = first_value(row.garage_id, row.parking, row.garage, row.parked_at)
+    local nickname = row.nickname
+    local engine = first_value(row.engine, mods.engineHealth, mods.engine)
+    local body = first_value(row.body, mods.bodyHealth, mods.body)
+    local fuel = normalized_health(first_value(row.fuel, mods.fuelLevel, mods.fuel), 100)
+    local msk_fuel
+    local kind = first_value(row.garage_type, row.type, mods.type)
+    if garage_system == "msk" then
+        kind = first_value(row.type, mods.type)
+        location = row.garage
+        nickname = row.name
+        engine = first_value(mods.engineHealth, mods.engine, row.engine)
+        body = first_value(mods.bodyHealth, mods.body, row.body)
+        if GetResourceState("msk_fuel") == "started" then
+            -- Liters need a model-specific capacity before they can be shown as a percentage.
+            msk_fuel = tonumber(first_value(row.fuel, mods.fuelLevel, mods.fuel))
+            fuel = nil
+        end
+    end
     local plate = tostring(first_value(row.plate, mods.plate) or ""):match("^%s*(.-)%s*$")
     return {
         id = tostring(first_value(row.id, row.vin, plate)),
         plate = plate,
         vin = tostring(row.vin or ""),
-        nickname = tostring(row.nickname or ""),
+        nickname = tostring(nickname or ""),
         model = model,
         imageUrl = vehicle_image_url(model),
-        kind = vehicle_kind(first_value(row.garage_type, row.type, mods.type)),
+        kind = vehicle_kind(kind),
         status = vehicle_status(row, location, garage_system),
         location = tostring(location or ""),
-        fuel = normalized_health(first_value(row.fuel, mods.fuelLevel, mods.fuel), 100),
-        engine = normalized_health(first_value(row.engine, mods.engineHealth, mods.engine), 1000),
-        body = normalized_health(first_value(row.body, mods.bodyHealth, mods.body), 1000),
+        fuel = fuel,
+        mskFuel = msk_fuel,
+        engine = normalized_health(engine, 1000),
+        body = normalized_health(body, 1000),
     }
 end
 
@@ -197,6 +238,9 @@ local function storage_config()
     end
     if system == "auto" and GetResourceState("jg-advancedgarages") == "started" then
         system = "jg"
+    end
+    if system == "auto" and GetResourceState("msk_garage") == "started" then
+        system = "msk"
     end
     if Bridge.Framework.GetName() == "esx" then
         return "owned_vehicles", "owner", system == "auto" and "esx" or system
@@ -227,7 +271,11 @@ local function owned_vehicle_row(identifier, plate)
     return rows[1], table_name, owner_column, garage_system
 end
 
-local function status_snapshot(row)
+local function status_snapshot(row, garage_system, table_name)
+    if garage_system == "msk" then
+        local column = table_name == "owned_vehicles" and "stored" or "state"
+        return { [column] = row[column] }
+    end
     local snapshot = {}
     for _, column in ipairs({ "stored", "state", "in_garage", "parked" }) do
         if row[column] ~= nil then
@@ -238,6 +286,23 @@ local function status_snapshot(row)
 end
 
 local function write_vehicle_status(order, restore)
+    if order.garage_system == "msk" then
+        local column, original_value = next(order.status)
+        if not column then
+            return false
+        end
+        local result = Bridge.Database.Query(
+            ("UPDATE `%s` SET `%s` = ? WHERE `%s` = ? AND TRIM(plate) = ? AND `%s` = ?")
+                :format(order.table_name, column, order.owner_column, column),
+            { restore and original_value or 0, order.identifier, order.plate, restore and 0 or original_value }
+        )
+        if type(result) ~= "table" or tonumber(result.affectedRows) ~= 1 then
+            Bridge.Debug("error", "[sky_phone] MSK valet order '%s' could not %s its vehicle status.",
+                tostring(order.id), restore and "restore" or "reserve")
+            return false, "vehicle_not_garaged"
+        end
+        return true
+    end
     local assignments = {}
     local parameters = {}
     for column, original_value in pairs(order.status) do
@@ -326,14 +391,16 @@ Bridge.Callbacks.Register("sky_phone:garage:valet-request", function(source, dat
         cost = price,
         expires_at = now + valet.TimeoutSeconds,
         identifier = identifier,
+        garage_system = garage_system,
         id = ("%s:%s:%s"):format(source, now, math.random(100000, 999999)),
         owner_column = owner_column,
         plate = plate,
-        status = status_snapshot(row),
+        status = status_snapshot(row, garage_system, table_name),
         table_name = table_name,
     }
-    if not write_vehicle_status(order, false) then
-        return { success = false, error = "valet_status_unsupported" }
+    local reserved, status_error = write_vehicle_status(order, false)
+    if not reserved then
+        return { success = false, error = status_error or "valet_status_unsupported" }
     end
     if price > 0 and not Bridge.Framework.RemoveMoney(source, valet.Account, price) then
         write_vehicle_status(order, true)
@@ -350,11 +417,12 @@ Bridge.Callbacks.Register("sky_phone:garage:valet-request", function(source, dat
             vehicle = {
                 body = vehicle.body,
                 engine = vehicle.engine,
-                fuel = vehicle.fuel,
+                fuel = vehicle.mskFuel or vehicle.fuel,
+                garageSystem = garage_system,
                 kind = vehicle.kind,
                 model = vehicle.model,
                 plate = vehicle.plate,
-                properties = vehicle_properties(row),
+                properties = vehicle_properties(row, garage_system),
             },
         },
     }

--- a/sky_phone/source/shared/config_default.lua
+++ b/sky_phone/source/shared/config_default.lua
@@ -399,7 +399,7 @@ Config.Billing = {
 }
 
 Config.Garage = {
-    System = "auto", -- auto, custom, esx, qb, qbox, ak47, bp, cd, codem, ds-servercreator, hex, jg, my, okok, op, quasar, rx, vms, ws, zyke_garages
+    System = "auto", -- auto, custom, esx, qb, qbox, ak47, bp, cd, codem, ds-servercreator, hex, jg, msk, my, okok, op, quasar, rx, vms, ws, zyke_garages
     MaximumVehicles = 250,
     RequestsPerMinute = 30,
     VehicleImages = {

--- a/tests/client_garage_valet.lua
+++ b/tests/client_garage_valet.lua
@@ -1,0 +1,222 @@
+local function new_client(options)
+    options = options or {}
+    local test = {
+        now = 0, threads = {}, events = {}, callbacks = {}, entities = {},
+        completions = 0, leave_count = 0, deleted = {},
+    }
+    local env = setmetatable({}, { __index = _G })
+    local vector_mt = {}
+    local function vector(x, y, z)
+        return setmetatable({ x = x, y = y, z = z }, vector_mt)
+    end
+    vector_mt.__sub = function(a, b) return vector(a.x - b.x, a.y - b.y, a.z - b.z) end
+    vector_mt.__len = function(a) return math.sqrt(a.x * a.x + a.y * a.y + a.z * a.z) end
+
+    env.Config = {
+        Bridge = { Locale = "en" },
+        Garage = { Valet = {
+            SpawnDistance = 110.0, ArrivalDistance = 14.0, DriveSpeed = 20.0,
+            DrivingStyle = 786603, TimeoutSeconds = 180,
+        } },
+    }
+    env.SkyPhoneLocales = { Resolve = function()
+        return { Nui = { Apps = { garage = { errors = {} } } } }
+    end }
+    env.GetGameTimer = function() return test.now end
+    env.GetCurrentResourceName = function() return "sky_phone" end
+    env.RegisterNetEvent = function(name, callback) test.events[name] = callback end
+    env.AddEventHandler = env.RegisterNetEvent
+    env.RegisterNUICallback = function(name, callback) test.callbacks[name] = callback end
+    env.SendNUIMessage = function(message) test.state = message.data end
+    env.CreateThread = function(callback)
+        test.threads[#test.threads + 1] = { co = coroutine.create(callback), wake = test.now }
+    end
+    env.Wait = function(ms) return coroutine.yield(ms) end
+    env.SetTimeout = function(ms, callback)
+        test.threads[#test.threads + 1] = { co = coroutine.create(callback), wake = test.now + ms }
+    end
+    env.Bridge = {
+        Framework = { Notify = function() end },
+        Callbacks = { Trigger = function(name)
+            if name == "sky_phone:garage:valet-request" then
+                return { success = true, data = {
+                    orderId = "test-order", cost = 750, driverModel = "valet",
+                    vehicle = { model = 1, plate = "VALET", properties = {} },
+                } }
+            end
+            if name == "sky_phone:garage:valet-complete" then
+                test.completions = test.completions + 1
+                if options.completion_delay then env.Wait(options.completion_delay) end
+                return { success = not options.completion_failure }
+            end
+            assert(name == "sky_phone:garage:valet-cancel", name)
+            return { success = true }
+        end },
+    }
+    env.joaat = function(value) return value end
+    env.PlayerPedId = function() return 1 end
+    env.IsModelInCdimage = function() return 1 end
+    env.IsModelAVehicle = function() return 1 end
+    env.HasModelLoaded = function() return 1 end
+    env.GetGamePool = function() return {} end
+    env.GetDisplayNameFromVehicleModel = function() return "TEST" end
+    env.GetLabelText = function() return "Test vehicle" end
+    env.GetEntityCoords = function() return vector(0.0, 0.0, 0.0) end
+    env.GetOffsetFromEntityInWorldCoords = function(_, x, y, z) return vector(x, y, z) end
+    env.GetClosestVehicleNodeWithHeading = function() return 1, vector(0.0, 0.0, 0.0), 0.0 end
+    env.GetEntityHeading = function() return 0.0 end
+    env.CreateVehicle = function()
+        test.entities[2] = { kind = "vehicle" }
+        return 2
+    end
+    env.CreatePedInsideVehicle = function()
+        test.entities[3] = { kind = "driver", in_vehicle = true }
+        return 3
+    end
+    env.DoesEntityExist = function(entity) return test.entities[entity] and 1 or nil end
+    env.IsEntityDead = function() return nil end
+    env.IsVehicleDriveable = function() return 1 end
+    env.NetworkGetNetworkIdFromEntity = function(entity) return entity end
+    env.AddBlipForEntity = function() return 4 end
+    env.DoesBlipExist = function() return 1 end
+    env.SetEntityAsMissionEntity = function(entity) test.entities[entity].owned = true end
+    env.SetEntityAsNoLongerNeeded = function(entity) test.entities[entity].owned = false end
+    env.DeleteEntity = function(entity)
+        assert(test.entities[entity], "must not delete a missing entity")
+        test.entities[entity] = nil
+        test.deleted[entity] = (test.deleted[entity] or 0) + 1
+    end
+    env.TaskVehicleDriveToCoordLongrange = function(driver)
+        test.entities[driver].driving = true
+    end
+    env.ClearPedTasks = function(driver)
+        test.entities[driver].driving = false
+    end
+    env.TaskLeaveVehicle = function(driver)
+        test.leave_count = test.leave_count + 1
+        test.leave_started = test.now
+        test.entities[driver].exit_at = options.blocked_exit and math.huge or test.now + 1000
+    end
+    env.IsPedInVehicle = function(driver)
+        local ped = test.entities[driver]
+        -- Seat occupancy can end before the exit/door animation has completed.
+        if ped.exit_at and test.now >= ped.exit_at then ped.in_vehicle = false end
+        return ped.in_vehicle and 1 or nil
+    end
+    env.GetScriptTaskStatus = function()
+        return test.now < test.leave_started + 1500 and 1 or 7
+    end
+    local function walk(driver, x, y, z, speed)
+        assert(math.type(x) == "float" and math.type(y) == "float" and math.type(z) == "float",
+            "OAL coordinates must be separate floats")
+        assert(speed == 1.0, "the driver must walk away")
+        test.walk_started = test.now
+        test.entities[driver].walking = true
+    end
+    env.TaskGoStraightToCoord = walk
+    env.TaskFollowNavMeshToCoord = walk
+    for _, name in ipairs({
+        "RequestModel", "SetModelAsNoLongerNeeded", "SetVehicleOnGroundProperly", "SetVehicleModKit",
+        "ToggleVehicleMod", "SetVehicleNumberPlateText", "SetVehicleHasBeenOwnedByPlayer",
+        "SetVehicleDoorsLocked", "SetVehicleEngineOn", "SetNetworkIdCanMigrate",
+        "SetBlockingOfNonTemporaryEvents", "SetPedKeepTask", "SetDriverAbility",
+        "SetDriverAggressiveness", "SetBlipSprite", "SetBlipColour", "SetBlipRoute",
+        "RemoveBlip", "TaskVehicleTempAction",
+    }) do
+        env[name] = function() end
+    end
+
+    function test.advance(ms)
+        local target = test.now + ms
+        while true do
+            local next_thread
+            for _, thread in ipairs(test.threads) do
+                if coroutine.status(thread.co) ~= "dead" and thread.wake <= target
+                    and (not next_thread or thread.wake < next_thread.wake)
+                then
+                    next_thread = thread
+                end
+            end
+            if not next_thread then break end
+            test.now = next_thread.wake
+            local success, delay = coroutine.resume(next_thread.co)
+            assert(success, delay)
+            next_thread.wake = test.now + (delay or 0)
+        end
+        test.now = target
+    end
+    function test.stop() test.events.onResourceStop("sky_phone") end
+    function test.abort() test.events["sky_phone:garage:valet-aborted"]("valet_timeout") end
+    assert(loadfile("sky_phone/source/client/garage.lua", "t", env))()
+    test.callbacks["garage:valet-request"]({ plate = "VALET" }, function(result)
+        assert(result.success, "request must be accepted")
+    end)
+    return test
+end
+
+local delivered = new_client()
+delivered.advance(3400)
+assert(delivered.state.status == "delivered" and delivered.completions == 1)
+assert(delivered.leave_count == 1, "the driver must only exit once")
+assert(delivered.walk_started >= delivered.leave_started + 1500,
+    "walking must wait until the normal exit animation is finished")
+assert(delivered.entities[3].walking and not delivered.entities[3].driving,
+    "the walking driver must have no driving task left to resume")
+assert(delivered.entities[3].owned, "the driver must stay under script control until despawn")
+delivered.advance(5000)
+assert(delivered.entities[3] and not delivered.entities[3].in_vehicle,
+    "the driver must remain outside while walking away")
+delivered.advance(5000)
+assert(not delivered.entities[3] and delivered.deleted[3] == 1, "the driver must despawn after walking")
+assert(delivered.entities[2], "despawning the valet must preserve the delivered vehicle")
+delivered.advance(12000)
+assert(delivered.state == nil, "the completed order must still clear normally")
+
+local blocked = new_client({ blocked_exit = true })
+blocked.advance(7000)
+assert(blocked.state.status == "delivered" and blocked.completions == 1)
+assert(not blocked.entities[3] and blocked.entities[2], "a blocked door must not leave the driver in the car")
+assert(not blocked.walk_started, "a seated driver must not be given an on-foot task")
+
+local failed = new_client({ completion_failure = true })
+failed.advance(3400)
+assert(failed.state.status == "failed" and not failed.entities[2] and not failed.entities[3],
+    "failed completion must clean up both valet entities")
+failed.entities[3] = { kind = "unrelated" }
+failed.advance(12000)
+assert(failed.entities[3], "a pending despawn must not delete a reused entity handle after failure")
+
+local stopped = new_client()
+stopped.advance(3400)
+stopped.stop()
+assert(stopped.entities[2] and not stopped.entities[3], "resource stop must clean up the departing driver only")
+stopped.entities[3] = { kind = "unrelated" }
+stopped.advance(12000)
+assert(stopped.entities[3], "a pending despawn must not delete a reused entity handle after resource stop")
+
+for _, abort_time in ipairs({ 1000, 2300 }) do
+    local aborted = new_client()
+    aborted.advance(abort_time)
+    aborted.abort()
+    aborted.advance(12000)
+    assert(aborted.completions == 0 and not aborted.walk_started,
+        "an aborted arrival must not continue with exit, walking, or completion")
+    assert(not aborted.entities[2] and not aborted.entities[3])
+end
+
+local interrupted = new_client({ completion_delay = 1000 })
+interrupted.advance(3400)
+interrupted.abort()
+interrupted.advance(12000)
+assert(interrupted.state == nil and not interrupted.entities[2] and not interrupted.entities[3],
+    "a late completion response must not resurrect an aborted order")
+
+local delayed = new_client({ completion_delay = 15000 })
+delayed.advance(14000)
+assert(delayed.entities[2] and not delayed.entities[3],
+    "driver cleanup must not be delayed by a pending server response")
+delayed.advance(5000)
+assert(delayed.state.status == "delivered" and delayed.entities[2],
+    "delivery must still complete if the driver has already despawned")
+
+print("Client garage valet tests passed (8 scenarios)")

--- a/tests/client_garage_valet.lua
+++ b/tests/client_garage_valet.lua
@@ -24,6 +24,27 @@ local function new_client(options)
     end }
     env.GetGameTimer = function() return test.now end
     env.GetCurrentResourceName = function() return "sky_phone" end
+    env.GetResourceState = function(name)
+        return name == "msk_fuel" and options.msk_fuel and "started" or "missing"
+    end
+    env.exports = { msk_fuel = {
+        SetVehicleFuel = function(_, vehicle, fuel)
+            assert(vehicle == 2)
+            test.msk_fuel = fuel
+        end,
+        Config = function()
+            test.fuel_config_reads = (test.fuel_config_reads or 0) + 1
+            return { PetrolTankVolume = { [1] = 200 } }
+        end,
+    } }
+    env.Entity = function(vehicle)
+        assert(vehicle == 2)
+        return { state = { set = function(_, key, fuel, replicated)
+            assert(key == "fuel" and replicated)
+            test.fuel_state = fuel
+        end } }
+    end
+    env.SetVehicleFuelLevel = function(_, fuel) test.native_fuel = fuel end
     env.RegisterNetEvent = function(name, callback) test.events[name] = callback end
     env.AddEventHandler = env.RegisterNetEvent
     env.RegisterNUICallback = function(name, callback) test.callbacks[name] = callback end
@@ -38,10 +59,13 @@ local function new_client(options)
     env.Bridge = {
         Framework = { Notify = function() end },
         Callbacks = { Trigger = function(name)
+            if name == "sky_phone:garage:vehicles" then
+                return { success = true, data = { vehicles = options.overview or {} } }
+            end
             if name == "sky_phone:garage:valet-request" then
                 return { success = true, data = {
                     orderId = "test-order", cost = 750, driverModel = "valet",
-                    vehicle = { model = 1, plate = "VALET", properties = {} },
+                    vehicle = options.vehicle or { model = 1, plate = "VALET", properties = {} },
                 } }
             end
             if name == "sky_phone:garage:valet-complete" then
@@ -61,6 +85,10 @@ local function new_client(options)
     env.GetGamePool = function() return {} end
     env.GetDisplayNameFromVehicleModel = function() return "TEST" end
     env.GetLabelText = function() return "Test vehicle" end
+    for _, name in ipairs({ "IsThisModelABoat", "IsThisModelAPlane", "IsThisModelAHeli",
+        "IsThisModelABike", "IsThisModelABicycle" }) do
+        env[name] = function() return nil end
+    end
     env.GetEntityCoords = function() return vector(0.0, 0.0, 0.0) end
     env.GetOffsetFromEntityInWorldCoords = function(_, x, y, z) return vector(x, y, z) end
     env.GetClosestVehicleNodeWithHeading = function() return 1, vector(0.0, 0.0, 0.0), 0.0 end
@@ -147,6 +175,11 @@ local function new_client(options)
     end
     function test.stop() test.events.onResourceStop("sky_phone") end
     function test.abort() test.events["sky_phone:garage:valet-aborted"]("valet_timeout") end
+    function test.overview()
+        local result
+        test.callbacks["garage:vehicles"]({}, function(value) result = value end)
+        return result.data.vehicles
+    end
     assert(loadfile("sky_phone/source/client/garage.lua", "t", env))()
     test.callbacks["garage:valet-request"]({ plate = "VALET" }, function(result)
         assert(result.success, "request must be accepted")
@@ -219,4 +252,34 @@ delayed.advance(5000)
 assert(delayed.state.status == "delivered" and delayed.entities[2],
     "delivery must still complete if the driver has already despawned")
 
-print("Client garage valet tests passed (8 scenarios)")
+local msk_liters = new_client({ msk_fuel = true, vehicle = {
+    model = 1, plate = "VALET", garageSystem = "msk", fuel = 140, properties = { fuelLevel = 20 },
+} })
+msk_liters.advance(0)
+assert(msk_liters.msk_fuel == 140 and msk_liters.native_fuel == nil,
+    "MSK's stored liters must reach its fuel export without the percentage clamp")
+
+local msk_standard = new_client({ vehicle = {
+    model = 1, plate = "VALET", garageSystem = "msk", fuel = 45, properties = { fuelLevel = 99 },
+} })
+msk_standard.advance(0)
+assert(msk_standard.native_fuel == 45 and msk_standard.fuel_state == 45,
+    "MSK's fuel column must override properties and restore its fuel state bag")
+
+local other_provider = new_client({ msk_fuel = true, vehicle = {
+    model = 1, plate = "VALET", garageSystem = "esx", fuel = 45, properties = { fuelLevel = 99 },
+} })
+other_provider.advance(0)
+assert(other_provider.native_fuel == 99 and other_provider.msk_fuel == nil,
+    "other garage providers must keep their existing fuel behavior")
+
+local msk_overview = new_client({ msk_fuel = true, overview = {
+    { model = 1, mskFuel = 140 }, { model = 1, mskFuel = 40 }, { model = 2, mskFuel = 40 },
+} })
+local vehicles = msk_overview.overview()
+assert(vehicles[1].fuel == 70 and vehicles[2].fuel == 20 and vehicles[3].fuel == nil,
+    "fuel percentages require a known model tank capacity")
+assert(msk_overview.fuel_config_reads == 1, "read MSK fuel config once per overview")
+for _, vehicle in ipairs(vehicles) do assert(vehicle.mskFuel == nil, "keep provider data out of NUI") end
+
+print("Client garage valet tests passed (12 scenarios)")

--- a/tests/phone_configurator.lua
+++ b/tests/phone_configurator.lua
@@ -127,6 +127,21 @@ local function test(name, callback)
     end
 end
 
+test("MSK garage selection survives SQL reload and reaches connected phones", function()
+    local server = new_server()
+    local client = new_client(server)
+    local garage = server.field("Garage").value
+    assert(garage.System == "auto")
+    assert(server.field("Garage").structure.fields.System.valueType == "string")
+    garage.System = "msk"
+    assert(server.save({ change("Garage", garage) }).success)
+    client.sync(server.broadcasts[1])
+    assert(server.env.Config.Garage.System == "msk" and client.config.Garage.System == "msk")
+    local restarted = new_server(server.database)
+    assert(restarted.field("Garage").value.System == "msk")
+    assert(new_client(restarted).config.Garage.System == "msk")
+end)
+
 test("false scalar settings save together with other panel changes and survive reload", function()
     local server = new_server()
     local apps = server.field("Apps").value

--- a/tests/server_garage.lua
+++ b/tests/server_garage.lua
@@ -1,0 +1,270 @@
+local function copy(value)
+    if type(value) ~= "table" then return value end
+    local result = {}
+    for key, child in pairs(value) do result[key] = copy(child) end
+    return result
+end
+
+local function new_server(options)
+    options = options or {}
+    local test = { callbacks = {}, events = {}, queries = {}, logs = {}, charged = 0, refunded = 0 }
+    local framework = options.framework or "esx"
+    local owner_column = framework == "esx" and "owner" or "citizenid"
+    local parked_column = framework == "esx" and "stored" or "state"
+    local table_name = framework == "esx" and "owned_vehicles" or "player_vehicles"
+    test.rows = options.rows or { {
+        owner = "owner-1", citizenid = "owner-1", plate = " MSK123 ",
+        stored = 1, state = 1, garage = "A", name = "My Sultan", type = "car", fuel = 45,
+        vehicle = framework == "esx" and "{properties}" or "sultan", mods = "{properties}",
+    } }
+    local resources = options.resources or { msk_garage = "started" }
+    local env = setmetatable({
+        Config = { Garage = {
+            System = options.system or "msk", MaximumVehicles = 250, RequestsPerMinute = 30,
+            VehicleImages = { Enabled = false },
+            Valet = {
+                Enabled = true, Price = 750, Account = "bank", RequestsPerMinute = 3,
+                CooldownSeconds = 60, TimeoutSeconds = 180, DriverModel = "s_m_m_autoshop_01",
+                VehicleTypes = { car = true, bike = true },
+            },
+        } },
+        GetResourceState = function(name) return resources[name] or "missing" end,
+        GetCurrentResourceName = function() return "sky_phone" end,
+        TriggerClientEvent = function() end,
+        CreateThread = function(callback) test.timeout_thread = coroutine.create(callback) end,
+        Wait = coroutine.yield,
+        NetworkGetEntityFromNetworkId = function(id) return id == 10 and 100 or 0 end,
+        DoesEntityExist = function(entity) return entity == 100 and 1 or nil end,
+        NetworkGetEntityOwner = function() return 1 end,
+        os = { time = function() return test.now or 1000 end },
+        json = { decode = function(value)
+            assert(value == "{properties}", "malformed JSON")
+            return { model = 970598228, plate = "MSK123", fuelLevel = 99, engineHealth = 850,
+                bodyHealth = 730, modEngine = 3 }
+        end },
+        SkyPhone = {
+            AllowOperation = function() return not options.rate_limited end,
+            RequireSession = function()
+                if options.no_session then return nil, { success = false, error = "no_session" } end
+                return {}
+            end,
+        },
+    }, { __index = _G })
+    env.AddEventHandler = function(name, callback) test.events[name] = callback end
+    env.Bridge = {
+        Debug = function(_, message) test.logs[#test.logs + 1] = message end,
+        Framework = {
+            GetName = function() return framework end,
+            GetIdentifier = function(source) return "owner-" .. source end,
+            GetMoney = function() return options.balance or 1000 end,
+            RemoveMoney = function(_, account, amount)
+                assert(account == "bank")
+                if options.payment_failure then return false end
+                test.charged = test.charged + amount
+                return true
+            end,
+            AddMoney = function(_, account, amount)
+                assert(account == "bank")
+                test.refunded = test.refunded + amount
+                return true
+            end,
+        },
+        Callbacks = { Register = function(name, callback) test.callbacks[name] = callback end },
+        Database = {
+            AfterMigration = function(_, callback) callback() end,
+            Query = function(sql, params)
+                test.queries[#test.queries + 1] = { sql = sql, params = copy(params) }
+                assert(sql:find(table_name, 1, true), "wrong framework table")
+                assert(sql:find(owner_column, 1, true), "missing owner scope")
+                if sql:find("SELECT", 1, true) == 1 then
+                    local result = {}
+                    for _, row in ipairs(test.rows) do
+                        local plate = row.plate:match("^%s*(.-)%s*$")
+                        if row[owner_column] == params[1]
+                            and (not sql:find("TRIM(plate)", 1, true) or plate == params[2])
+                        then
+                            result[#result + 1] = copy(row)
+                        end
+                    end
+                    return result
+                end
+                local changed = 0
+                assert(sql:find("UPDATE", 1, true) == 1)
+                assert(sql:find("SET `" .. parked_column .. "` = ?", 1, true),
+                    "MSK must write only its framework parked flag")
+                for _, row in ipairs(test.rows) do
+                    if options.reservation_race then row[parked_column] = 0 end
+                    local stored = row[parked_column]
+                    if stored == true then stored = 1 elseif stored == false then stored = 0 end
+                    local expected = params[4]
+                    if expected == true then expected = 1 elseif expected == false then expected = 0 end
+                    if row[owner_column] == params[2]
+                        and row.plate:match("^%s*(.-)%s*$") == params[3]
+                        and tonumber(stored) == tonumber(expected)
+                    then
+                        row[parked_column] = params[1]
+                        changed = changed + 1
+                    end
+                end
+                return { affectedRows = changed }
+            end,
+        },
+    }
+    assert(loadfile("sky_phone/source/server/garage.lua", "t", env))()
+    function test.call(action, data, source)
+        return test.callbacks["sky_phone:garage:" .. action](source or 1, data)
+    end
+    function test.overview() return test.call("vehicles").data.vehicles end
+    function test.request(plate) return test.call("valet-request", { plate = plate or "MSK123", price = 0 }) end
+    function test.cancel(order) return test.call("valet-cancel", { orderId = order.data.orderId }) end
+    function test.stop() test.events.onResourceStop("sky_phone") end
+    function test.disconnect()
+        env.source = 1
+        test.events.playerDropped()
+    end
+    function test.timeout()
+        assert(coroutine.resume(test.timeout_thread))
+        test.now = 1181
+        assert(coroutine.resume(test.timeout_thread))
+    end
+    return test
+end
+
+local scenarios = 0
+local function scenario(name, callback)
+    callback()
+    scenarios = scenarios + 1
+    print("PASS " .. name)
+end
+
+for _, framework in ipairs({ "esx", "qb", "qbox" }) do
+    scenario(framework .. " MSK ownership, mapping and valet lifecycle", function()
+        local test = new_server({ framework = framework, system = "auto" })
+        local row = test.rows[1]
+        -- Legacy data from a previous garage must neither override nor be modified by MSK.
+        row.in_garage, row.parked, row.impound = 1, 1, 1
+        row.garage_id, row.parking, row.nickname = "old_impound", "old_parking", "old name"
+        row.engine, row.body = 1000, 1000
+        row.model = 123
+        if framework == "esx" then row.state = 2 else row.stored = 0 end
+        local vehicle = test.overview()[1]
+        assert(vehicle.plate == "MSK123" and vehicle.nickname == "My Sultan")
+        assert(vehicle.model == 970598228, "MSK properties must decide the vehicle model")
+        assert(vehicle.location == "A" and vehicle.status == "garaged")
+        assert(vehicle.fuel == 45 and vehicle.engine == 85 and vehicle.body == 73)
+        assert(#test.call("vehicles", nil, 2).data.vehicles == 0, "other owners must not see vehicles")
+        assert(test.call("valet-request", { plate = "MSK123" }, 2).error == "vehicle_not_owned")
+        local before = copy(row)
+        local order = test.request(" MSK123 ")
+        assert(order.success, tostring(order.error))
+        assert(order.data.vehicle.properties.modEngine == 3)
+        assert(order.data.vehicle.garageSystem == "msk" and order.data.vehicle.fuel == 45)
+        assert(test.charged == 750 and order.data.cost == 750, "server must decide the price")
+        assert(test.overview()[1].status == "out")
+        assert(test.request().error == "valet_active")
+        assert(test.call("valet-cancel", { orderId = "wrong" }).error == "valet_not_found")
+        assert(test.refunded == 0)
+        local column = framework == "esx" and "stored" or "state"
+        for key, value in pairs(before) do
+            assert(row[key] == (key == column and 0 or value), "unexpected mutation: " .. key)
+        end
+        assert(test.cancel(order).success and test.refunded == 750)
+        for key, value in pairs(before) do assert(row[key] == value, "restore changed " .. key) end
+        assert(test.overview()[1].status == "garaged")
+    end)
+end
+
+scenario("auto keeps JG priority and explicit MSK overrides it", function()
+    local resources = { msk_garage = "started", ["jg-advancedgarages"] = "started" }
+    local auto = new_server({ system = "auto", resources = resources })
+    auto.rows[1].in_garage = 0
+    assert(auto.overview()[1].status == "out")
+    local explicit = new_server({ resources = resources })
+    explicit.rows[1].in_garage = 0
+    assert(explicit.overview()[1].status == "garaged")
+end)
+
+scenario("auto falls back to the framework without MSK", function()
+    local test = new_server({ system = "auto", resources = {} })
+    test.rows[1].nickname = "ESX nickname"
+    test.rows[1].state = 2
+    assert(test.overview()[1].status == "impounded")
+    assert(test.overview()[1].nickname == "ESX nickname")
+end)
+
+scenario("out MSK vehicles remain out despite stale parked flags", function()
+    local test = new_server()
+    test.rows[1].stored, test.rows[1].in_garage = 0, 1
+    assert(test.overview()[1].status == "out")
+    assert(test.request().error == "vehicle_not_garaged")
+    assert(test.charged == 0)
+end)
+
+scenario("MSK aircraft cannot use road-only valet", function()
+    local test = new_server()
+    test.rows[1].type = "aircraft"
+    test.rows[1].garage_type = "car"
+    assert(test.overview()[1].kind == "plane")
+    assert(test.request().error == "valet_vehicle_type")
+    assert(test.charged == 0)
+end)
+
+scenario("failed payment restores MSK status without a refund", function()
+    local test = new_server({ payment_failure = true })
+    assert(test.request().error == "insufficient_funds")
+    assert(test.rows[1].stored == 1 and test.charged == 0 and test.refunded == 0)
+end)
+
+scenario("concurrent park-out cannot create a second MSK valet order", function()
+    local test = new_server({ reservation_race = true })
+    assert(test.request().error == "vehicle_not_garaged")
+    assert(test.charged == 0 and test.rows[1].stored == 0 and #test.logs == 1)
+end)
+
+for _, action in ipairs({ "stop", "disconnect", "timeout" }) do
+    scenario(action .. " restores an undelivered MSK vehicle", function()
+        local test = new_server()
+        assert(test.request().success)
+        test[action]()
+        assert(test.rows[1].stored == 1 and test.refunded == 750)
+    end)
+end
+
+scenario("completion leaves the delivered vehicle out", function()
+    local test = new_server()
+    local order = test.request()
+    assert(test.call("valet-complete", { orderId = order.data.orderId, networkId = 0 }).error
+        == "valet_vehicle_unverified")
+    assert(test.call("valet-complete", { orderId = order.data.orderId, networkId = 10 }).success)
+    test.stop()
+    assert(test.rows[1].stored == 0 and test.refunded == 0)
+    assert(test.request().error == "valet_cooldown")
+end)
+
+scenario("rollback never overwrites a new owner's row", function()
+    local test = new_server()
+    local order = test.request()
+    test.rows[1].owner = "owner-2"
+    assert(test.cancel(order).success)
+    assert(test.rows[1].stored == 0 and #test.logs == 1)
+end)
+
+scenario("MSK fuel liters remain unrounded for valet", function()
+    local test = new_server({ resources = { msk_garage = "started", msk_fuel = "started" } })
+    test.rows[1].fuel = 140
+    local vehicle = test.overview()[1]
+    assert(vehicle.fuel == nil and vehicle.mskFuel == 140, "liters are not a percentage")
+    local order = test.request()
+    assert(order.success and order.data.vehicle.fuel == 140)
+end)
+
+scenario("session and rate limits still protect MSK access", function()
+    local blocked = new_server({ rate_limited = true })
+    assert(blocked.call("vehicles").error == "rate_limited")
+    assert(blocked.request().error == "rate_limited" and #blocked.queries == 0)
+    local no_session = new_server({ no_session = true })
+    assert(no_session.call("vehicles").error == "no_session")
+    assert(no_session.request().error == "no_session" and #no_session.queries == 0)
+end)
+
+print(("Server garage tests passed (%d scenarios)"):format(scenarios))


### PR DESCRIPTION
## Summary

Add MSK Garage support to the phone's vehicle overview and valet service. Stored vehicle names, locations, properties and fuel now follow MSK's framework schema. After a valet delivery, the driver leaves the vehicle, walks away and despawns while the delivered vehicle remains available.

Related issue: None; requested directly.

## Root cause and approach

The garage adapter did not recognize `msk_garage`. Generic status and property selection could read stale columns left by another garage provider. The MSK path uses the framework's authoritative parked flag and reserves it with an owner-scoped conditional update before charging for delivery.

The existing valet cleanup fix is also included: delivery completion waits for the driver's exit and walking phase before removing the driver.

## Changes

- Add explicit `msk` selection and automatic detection after JG.
- Map MSK vehicle names, garage IDs, vehicle categories and properties on ESX, QBCore and Qbox.
- Update only MSK's parked flag for valet reservations and rollback; preserve MSK fuel liters and restore its fuel state.
- Add English/German/Spanish Configurator guidance, SQL save/load coverage and installation documentation.
- Add garage server tests and extend valet client tests, including delivery cleanup, cancellation, payment failure and provider fuel behavior.

## Compatibility and migrations

- No SQL migration is required.
- Keep `Garage.System = "auto"` or select `msk`; with the Phone Configurator enabled, set the value in `/phonepanel`.
- Start `msk_garage` before `sky_phone`. If JG also runs, explicitly select `msk`.
- Uses the standard ESX vehicle schema, or the QBCore/Qbox schema supported by MSK 5.6+.
- MSK fuel percentages require a configured model tank capacity; otherwise the percentage remains unavailable.
- English, German and Spanish locale files and generated Configurator defaults are updated. Rebuild the NUI when deploying from source.

## Validation

- [x] I ran the narrowest relevant automated tests.
- [ ] I ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` for frontend changes.
- [x] I ran a production frontend build for frontend changes.
- [x] I tested affected Lua/native behavior with experimental OAL enabled, or marked the live runtime test as pending below.
- [ ] I verified every changed NUI callback responds on every reachable path.
- [x] I reviewed the final diff and excluded unrelated work and generated-only edits.

Commands and results:

```text
lua54 tests/server_garage.lua
  Passed: 16 scenarios
lua54 tests/client_garage_valet.lua
  Passed: 12 scenarios
lua54 tests/phone_configurator.lua
  Passed, including MSK persistence/runtime sync and company profile sync
Lua loadfile checks for changed runtime/config/locale files
  Passed
node .github/scripts/validate-repository.mjs
  Passed
pnpm exec vitest run src/utils/adminConfiguratorDescription.test.ts testserver/configurator-fixture.test.ts src/stores/garage.test.ts
  Passed: 13 tests
pnpm exec eslint src/utils/adminConfiguratorDescription.ts src/utils/adminConfiguratorDescription.test.ts
  Passed
pnpm exec vitest run src/stores/phone-locale-contract.test.ts
  Passed: 14 tests after adding the missing Spanish Configurator description
build_copy.bat after the locale correction
  Passed; Spanish locale SHA256 matches both local deployments
build_frontend.bat
  Passed: typecheck, production build and local ESX/Qbox copies
SHA256 comparison
  Matched 294 changed-resource/built-asset files in each local deployment
git diff --check
  Passed
```

The full frontend lint/test suites are left to CI; local frontend checks were scoped to the affected behavior. Callback success paths are covered by mocks; exhaustive external-provider failure-path verification remains pending.

## Runtime evidence

No restarted FiveM/MSK gameplay test has been performed. Local build and deployment parity are verified; these do not prove live behavior with OAL, MSK Garage or MSK Fuel. In-game vehicle listing, delivery, cancellation and driver cleanup still need validation.

## Security and architecture

- [x] Consequential actions remain server-authoritative and validate identity, permissions, ownership, limits, and payloads.
- [x] This change introduces no dependency, event, export, global, config, persistence, or fallback connection to another `sky_*` resource.
- [x] No secret, credential, private URL, or personal player data is included.

## Reviewer notes

Depends on #60. Review and merge the valet driver fix first. Both PRs target `dev` because repository policy requires that base; this PR currently includes the prerequisite commit.

This branch includes `15394a1c` (valet driver cleanup), `efcb791d` (MSK Garage support) and `29812196` (Spanish locale parity). MSK uses its parked flag to distinguish garaged vehicles from vehicles outside; the phone displays outside vehicles as out and restricts valet requests to parked, personally owned vehicles. Check the installed provider's schema if its column mappings were customized.
